### PR TITLE
Add better error messages if axis/axes are not part of tensor (#6).

### DIFF
--- a/core/src/main/scala/dimwit/package.scala
+++ b/core/src/main/scala/dimwit/package.scala
@@ -42,12 +42,6 @@ package object dimwit:
   export dimwit.tensor.{DType, Device}
   export dimwit.tensor.{VType, ExecutionType, Label, Labels, Axis, AxisIndex, AxisIndices, Dim}
 
-  // Export type helpers
-  export dimwit.tensor.Axis.UnwrapAxes
-  export dimwit.tensor.TupleHelpers.*
-  export dimwit.tensor.Join
-  export Prime.*
-
   // Export operations
   export dimwit.tensor.TensorOps.*
 

--- a/core/src/main/scala/dimwit/tensor/Labels.scala
+++ b/core/src/main/scala/dimwit/tensor/Labels.scala
@@ -1,9 +1,7 @@
 package dimwit.tensor
 
-import dimwit.tensor.TupleHelpers.{RemoverAll, Replacer}
 import scala.compiletime.*
 import scala.quoted.*
-import dimwit.tensor.TupleHelpers.PrimeConcat
 
 trait Label[T]:
   def name: String
@@ -53,34 +51,8 @@ object Labels extends LabelsLowPriority:
     v.name :: t.names
   )
 
-  given derivedReplacer[T <: Tuple, ToReplace, OutAxis, O <: Tuple](using
-      replacer: Replacer[T, ToReplace, OutAxis] { type Out = O },
-      labels: Labels[T],
-      toReplaceLabels: Label[ToReplace],
-      outAxisValue: Label[OutAxis]
-  ): Labels[O] =
-    val toReplaceNames = List(toReplaceLabels.name)
-    LabelsImpl[O](
-      labels.names.map { name =>
-        if toReplaceNames.contains(name) then outAxisValue.name else name
-      }
-    )
-
   object ForConcat:
-
     given [T1 <: Tuple, T2 <: Tuple](using
         n1: Labels[T1],
         n2: Labels[T2]
     ): Labels[Tuple.Concat[T1, T2]] = new LabelsImpl(n1.names ++ n2.names)
-
-  object ForPrimeConcat:
-    given derivePrimeConcat[T1 <: Tuple, T2 <: Tuple](using
-        primeConcat: PrimeConcat[T1, T2],
-        n1: Labels[T1],
-        n2: Labels[T2]
-    ): Labels[primeConcat.Out] =
-      val n1Names = n1.names.toSet
-      val newN2Names = n2.names.map { name =>
-        if n1Names.contains(name) then s"${name}'" else name
-      }
-      new LabelsImpl(n1.names ++ newN2Names)

--- a/core/src/main/scala/dimwit/tensor/ShapeTypeHelpers.scala
+++ b/core/src/main/scala/dimwit/tensor/ShapeTypeHelpers.scala
@@ -1,0 +1,72 @@
+package dimwit.tensor
+
+import scala.annotation.implicitNotFound
+
+/* Helpers for tracking Tensor Shape types across various operations */
+object ShapeTypeHelpers:
+
+  import TupleHelpers.*
+
+  @implicitNotFound("Axis[${Axis}] not found in Tensor[${TensorShape}]")
+  trait AxisInTensor[TensorShape <: Tuple, Axis]:
+    def index: Int
+
+  trait AxisRemover[TensorShape <: Tuple, Axis, RemainingShape <: Tuple] extends AxisInTensor[TensorShape, Axis]
+
+  object AxisRemover:
+    given bridge[S <: Tuple, A, R <: Tuple](using
+        axisIndex: AxisIndex[S, A],
+        ev: RemoverAll.Aux[S, A *: EmptyTuple, R]
+    ): AxisRemover[S, A, R] with
+      def index: Int = axisIndex.value
+
+  trait AxisReplacer[TensorShape <: Tuple, Axis, AxisReplacement] extends AxisInTensor[TensorShape, Axis]:
+    type NewShape <: Tuple
+
+  object AxisReplacer:
+    type Aux[S <: Tuple, A, AR, O <: Tuple] = AxisReplacer[S, A, AR] { type NewShape = O }
+
+    given bridge[S <: Tuple, A, AR, O <: Tuple](using
+        idx: AxisIndex[S, A],
+        replacer: Replacer.Aux[S, A, AR, O]
+    ): AxisReplacer.Aux[S, A, AR, O] = new AxisReplacer[S, A, AR]:
+      def index: Int = idx.value
+      type NewShape = O
+
+  @implicitNotFound("Axes [${Axes}] not all found in Tensor shape [${TensorShape}]")
+  trait AxesInTensor[TensorShape <: Tuple, Axes <: Tuple]:
+    def indices: List[Int]
+
+  trait AxesRemover[TensorShape <: Tuple, Axes <: Tuple, RemainingShape <: Tuple] extends AxesInTensor[TensorShape, Axes]
+
+  object AxesRemover:
+    given bridge[T <: Tuple, Axes <: Tuple, R <: Tuple](using
+        idx: AxisIndices[T, Axes],
+        ev: RemoverAll.Aux[T, Axes, R]
+    ): AxesRemover[T, Axes, R] with
+      def indices: List[Int] = idx.values
+
+  trait AxesConditionalRemover[TensorShape <: Tuple, RemovedAxis <: Tuple, IndexAxes <: Tuple, RemainingShape <: Tuple] extends AxesInTensor[TensorShape, IndexAxes]
+
+  object AxesConditionalRemover:
+    given bridge[T <: Tuple, RemovedAxis <: Tuple, IndexAxes <: Tuple, R <: Tuple](using
+        idx: AxisIndices[T, IndexAxes],
+        ev: RemoverAll.Aux[T, RemovedAxis, R]
+    ): AxesConditionalRemover[T, RemovedAxis, IndexAxes, R] with
+      def indices = idx.values
+
+  @implicitNotFound("Axis[${Axis}] not found in ${Shapes}}")
+  trait SharedAxisRemover[Shapes <: Tuple, Axis, Sliced <: Tuple]:
+    def indices: List[Int]
+
+  object SharedAxisRemover:
+
+    given empty[Axis]: SharedAxisRemover[EmptyTuple, Axis, EmptyTuple] with
+      def indices = Nil
+      type Sliced = EmptyTuple
+
+    given cons[H <: Tuple, T <: Tuple, Axis, R <: Tuple, TailOut <: Tuple](using
+        evH: AxisRemover[H, Axis, R],
+        evT: SharedAxisRemover[T, Axis, TailOut]
+    ): SharedAxisRemover[H *: T, Axis, R *: TailOut] with
+      def indices = evH.index :: evT.indices

--- a/core/src/main/scala/dimwit/tensor/TupleHelpers.scala
+++ b/core/src/main/scala/dimwit/tensor/TupleHelpers.scala
@@ -2,6 +2,7 @@ package dimwit.tensor
 
 import scala.util.NotGiven
 
+/* Helpers for manipulating Tuple types */
 object TupleHelpers:
 
   trait StrictSubset[S <: Tuple, T <: Tuple]
@@ -75,12 +76,14 @@ object TupleHelpers:
 
   object Replacer extends ReplacerLowPriority:
 
+    type Aux[T <: Tuple, Target, Replacement, O <: Tuple] = Replacer[T, Target, Replacement] { type Out = O }
+
     given found[Target, Tail <: Tuple, Replacement]: Replacer[Target *: Tail, Target, Replacement] with
       type Out = Replacement *: Tail
 
   trait ReplacerLowPriority:
     given recurse[Head, Tail <: Tuple, Target, Replacement, TailOut <: Tuple](using
-        next: Replacer[Tail, Target, Replacement] { type Out = TailOut }
+        next: Replacer.Aux[Tail, Target, Replacement, TailOut]
     ): Replacer[Head *: Tail, Target, Replacement] with
       type Out = Head *: TailOut
 

--- a/core/src/test/scala/dimwit/tensor/TensorCompileSuite.scala
+++ b/core/src/test/scala/dimwit/tensor/TensorCompileSuite.scala
@@ -1,0 +1,35 @@
+package dimwit.tensor
+
+import dimwit.*
+import org.scalatest.propspec.AnyPropSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import scala.compiletime.testing.typeCheckErrors
+
+class TensorCompileSuite extends AnyFunSpec with ScalaCheckPropertyChecks with Matchers:
+
+  it("Nice error message when axis not found in tensor for sum"):
+    val t = Tensor.zeros(Shape(Axis[A] -> 1, Axis[B] -> 2), VType[Float])
+    // val res = t.sum(Axis[C])
+    val errors = typeCheckErrors("t.sum(Axis[C])")
+    errors should have size 1
+    val error = errors.head
+    error.message should include("Axis[dimwit.tensor.C] not found in Tensor[(dimwit.tensor.A, dimwit.tensor.B)]")
+
+  it("Nice error message when axes not found in tensor for sum"):
+    val t = Tensor.zeros(Shape(Axis[A] -> 1, Axis[B] -> 2), VType[Float])
+    // val res = t.sum((Axis[A], Axis[C]))
+    val errors = typeCheckErrors("t.sum((Axis[A], Axis[C]))")
+    errors should have size 1
+    val error = errors.head
+    error.message should include("(dimwit.tensor.Axis[dimwit.tensor.A], dimwit.tensor.Axis[dimwit.tensor.C])]] not all found in Tensor shape [(dimwit.tensor.A, dimwit.tensor.B)]")
+
+  it("Nice error message when axes not found in zipvmap"):
+    val ab = Tensor.zeros(Shape(Axis[A] -> 1, Axis[B] -> 2), VType[Float])
+    val bc = Tensor.zeros(Shape(Axis[B] -> 2, Axis[C] -> 1), VType[Float])
+    // val res = zipvmap(Axis[C])(ab, bc) { case (x, y) => x.sum + y.sum }
+    val errors = typeCheckErrors("zipvmap(Axis[C])(ab, bc) { case (x, y) => x.sum + y.sum }")
+    errors should have size 1
+    val error = errors.head
+    error.message should include("Axis[dimwit.tensor.C]")

--- a/examples/src/main/scala/basic/Playground.scala
+++ b/examples/src/main/scala/basic/Playground.scala
@@ -16,10 +16,14 @@ trait C derives Label
 
 @main def playground(): Unit =
 
+  trait Batch derives Label
+  trait Batch2 derives Label
+  trait Features derives Label
+
   val t = Tensor.zeros(
     Shape(
-      Axis["Batch"] -> 4,
-      Axis["Features"] -> 8
+      Axis[Batch] -> 4,
+      Axis[Features] -> 8
     ),
     VType[Y]
   )
@@ -419,7 +423,7 @@ trait C derives Label
     }
     println(res.shape)
 
-    val res2 = zipvmap(Axis[Batch])(x, y, z) { (xi, yi, zi) =>
+    val res2 = zipvmap(Axis[Batch])(x, y, z) { case (xi, yi, zi) =>
       xi.sum + yi.sum + zi.sum
     }
     println(res2.shape)
@@ -574,15 +578,6 @@ trait C derives Label
     val axis1 = Axis[A |*| B]
     val axis2 = Axis[B |*| A]
 
-    type axisType = Axis[A | B]
-    val axis3: axisType = Axis[A | B]
-    val axis4: axisType = Axis[B | A] // <-- This should not work as A | B != B | A for rearrange
-
-    val contractAxis = Axis[B | C]
-    val res = ab.contract(contractAxis)(cd)
-    val cab1 = ab.contract(Axis[A])(ba)
-    val cab2 = ab.contract(Axis[A | B])(ba)
-    val cab3 = ab.contract(Axis[B | A])(ba)
     // type axisT = Axis[A] | Axis[B]
     // val axis: axisT = Axis[A]
     // val cab4 = ab.contract(axis)(ba)

--- a/src/python/jax_helper.py
+++ b/src/python/jax_helper.py
@@ -16,13 +16,16 @@ def vmap(f, dims):
     jax will crash upon inspection.
     """
                 
-    # Wrap the ScalaPy function in a pure Python wrapper
     def python_wrapper(x):
         return f(x)
             
-    # Create vmap with the wrapper
     return jax.vmap(python_wrapper, in_axes=dims)
-            
+           
+def zipvmap(f, dims):
+    def python_wrapper(*args):
+        return f(args)
+    return lambda jax_inputs_tuple: jax.vmap(python_wrapper, in_axes=dims)(*jax_inputs_tuple)
+
 def apply_over_axes(f, axis):
     """
     Applies a function `f` over specified axes using JAX's vmap functionality.


### PR DESCRIPTION
Main:
* Add nice error messages if Axis is not in Tensor
<img width="834" height="19" alt="image" src="https://github.com/user-attachments/assets/77c8f999-fa31-4b3b-b47e-6a0f5d7e431a" />

This was combined with a clean-up effort to enable it. 
* ShapeTypeHelpers are now type classes that combine common cases into a single type class. 
* All operations were refactored to use these new types (rather than multiple making errors hard to write)
* Zipvmap was cleaned up because the old Gemini implementation was weird.

Additionally
* Test added for the compile messages to catch breaking changes.