### PR TITLE
add gc method to dimwit package

### DIFF
--- a/core/src/main/scala/dimwit/package.scala
+++ b/core/src/main/scala/dimwit/package.scala
@@ -1,4 +1,7 @@
 import scala.annotation.targetName
+
+import dimwit.jax.Jax
+
 package object dimwit:
 
   import scala.compiletime.ops.string.+
@@ -23,6 +26,10 @@ package object dimwit:
             val oldLabels = summon[Labels[T]]
             oldLabels.names.toList.map(_.replace("'", ""))
         Tensor[RemovePrimes[T], V](tensor.jaxValue)
+
+  def gc(): Unit =
+    System.gc()
+    Jax.gc()
 
   @targetName("On")
   infix trait ~[A, B]


### PR DESCRIPTION
When running longer training loops, dimwit tends to run out of memory. A solution is to call both the Jax garbage collector and the JVM garbage collector. 

The added method combines the calls and also hides them in the dimwit package, such that the user is not exposed to Jax methods. 