### PR TITLE
Steer operation availability

### DIFF
--- a/core/src/test/scala/dimwit/tensor/TensorOpsBinarySuite.scala
+++ b/core/src/test/scala/dimwit/tensor/TensorOpsBinarySuite.scala
@@ -117,13 +117,6 @@ class TensorOpsBinarySuite extends AnyFunSpec with ScalaCheckPropertyChecks with
       checkBinary2Int(twoTensor2Gen(VType[Int]))("t1 * t2", _ * _)
       checkBinary2Int(twoTensor3Gen(VType[Int]))("t1 * t2", _ * _)
 
-    describe("Division /"):
-      val (min, max) = (1, 100) // guarantee no division by zero
-      checkBinary2Float(twoTensor0Gen(min, max))("t1 / t2", _ / _)
-      checkBinary2Float(twoTensor1Gen(min, max))("t1 / t2", _ / _)
-      checkBinary2Float(twoTensor2Gen(min, max))("t1 / t2", _ / _)
-      checkBinary2Float(twoTensor3Gen(min, max))("t1 / t2", _ / _)
-
     describe("Less than <"):
       checkBinary2Bool(twoTensor0Gen(VType[Int]))("t1 < t2", _ < _)
       checkBinary2Bool(twoTensor1Gen(VType[Int]))("t1 < t2", _ < _)

--- a/core/src/test/scala/dimwit/tensor/TensorWithValueClassSuite.scala
+++ b/core/src/test/scala/dimwit/tensor/TensorWithValueClassSuite.scala
@@ -1,0 +1,30 @@
+package dimwit.tensor
+
+import dimwit.*
+import org.scalatest.propspec.AnyPropSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import scala.compiletime.testing.typeCheckErrors
+
+class TensorWithValueClassSuite extends AnyFunSpec with ScalaCheckPropertyChecks with Matchers:
+
+  it("Nice error message when axis not found in tensor for sum"):
+    object ValueClassScope:
+      opaque type V1 = Float
+      opaque type V2 = Float
+
+      object V1:
+        def apply[T <: Tuple](t: Tensor[T, Float]): Tensor[T, V1] = t // lift
+        given IsFloat[V1] with {} // make all IsFloat ops available
+      object V2:
+        def apply[T <: Tuple](t: Tensor[T, Float]): Tensor[T, V2] = t // lift
+        given IsFloat[V2] with {} // make all IsFloat ops available
+
+    import ValueClassScope.*
+    val t = Tensor.zeros(Shape(Axis[A] -> 1, Axis[B] -> 2), VType[Float])
+    val v1 = V1(t)
+    val v2 = V2(t)
+    "v1 + v1" should compile
+    "v2 + v2" should compile
+    "v1 + v2" shouldNot compile

--- a/examples/src/main/scala/api/TensorAPI.scala
+++ b/examples/src/main/scala/api/TensorAPI.scala
@@ -294,11 +294,6 @@ def tensorAPI(): Unit =
       py.exec("res = jnp.tensordot(abcd, abcd, axes=(2, 2))") // pure JAX variant
       ABCD.contract(Axis[C])(ABCD)
     }
-    opBlock("matmul ab.T @ ac") {
-      // note there are some matrix specific contraction
-      py.exec("res = jnp.matmul(ab.T, ac)")
-      AB.transpose.matmul(AC)
-    }
 
     /** OUTER PRODUCT (contract over zero axes) Analog to JAX outer product, i.e., no axes to contract
       */
@@ -608,12 +603,14 @@ def tensorAPI(): Unit =
       AB.norm
     }
     opBlock("inv AB") {
-      val a1a2 = Tensor2.fromArray(Axis["A1"], Axis["A2"], VType[Float])(
-        Array(
-          Array(2f, 0f),
-          Array(0f, 2f)
+      val a1a2 = Tensor2
+        .fromArray(Axis["A1"], Axis["A2"], VType[Float])(
+          Array(
+            Array(2f, 0f),
+            Array(0f, 2f)
+          )
         )
-      )
+        .toDevice(Device.CPU)
       py.exec("a1a2 = jnp.array([[2, 0],[0, 2]])")
       py.exec("res = jnp.linalg.inv(a1a2)")
       a1a2.inv

--- a/examples/src/main/scala/basic/LogisticRegression.scala
+++ b/examples/src/main/scala/basic/LogisticRegression.scala
@@ -101,8 +101,8 @@ object LogisticRegression:
           println(
             List(
               "epoch: " + index,
-              "trainAcc: " + (1f - (trainPreds.asInt - trainLabels.asInt).abs.mean),
-              "valAcc: " + (1f - (valPreds.asInt - valLabels.asInt).abs.mean)
+              "trainAcc: " + (1f - (trainPreds.asFloat - trainLabels.asFloat).abs.mean),
+              "valAcc: " + (1f - (valPreds.asFloat - valLabels.asFloat).abs.mean)
             ).mkString(", ")
           )
       .map((params, _) => params)

--- a/examples/src/main/scala/basic/MLClassifierMNist.scala
+++ b/examples/src/main/scala/basic/MLClassifierMNist.scala
@@ -172,7 +172,7 @@ object MLPClassifierMNist:
         targets: Tensor1[Sample, Int]
     ): Tensor0[Float] =
       val matches = zipvmap(Axis[Sample])(predictions, targets)(_ === _)
-      matches.mean
+      matches.asFloat.mean
 
     def gradientStep(
         imageBatch: Tensor[(TrainSample, Height, Width), Float],


### PR DESCRIPTION
Steer operation availability by type classes IsNumber, IsFloat, IsInt, IsBool. For example, division is only available for Float Tensors.

Compared two JAX this results in two differences:
1. Some operations leading to a runtime error are not available.
For example:
JAX: boolTensor1 / boolTensor2 ==> Runtime error
DimWit: intTensor1.asFloat / intTensor2.asFloat ==> floatTensor

2. Some operations leading to implicit type change are not available and require a explicit cast.
For example:
JAX: intTensor1 / intTensor2 ==> floatTensor
DimWit: intTensor1.asFloat / intTensor2.asFloat ==> floatTensor

---

This branch implements this more strictly than before. Operations **never** change the underlying V type.
For example "mean" in DimWit changed the V type to Float (intTensor.mean ==> FloatTensor). However, this is problematic with more specialized types (opaque types), as the opaque type will be turned to Float. Now an explicit cast to float "asFloat" must be done to make "mean" available if the tensor is not a floattensor already:
<img width="632" height="70" alt="image" src="https://github.com/user-attachments/assets/71f719d1-a86a-4e43-a359-f2609f31d3d2" />
