### PR TITLE
remove metals.sbt files from git

### DIFF
--- a/project/metals.sbt
+++ b/project/metals.sbt
@@ -1,9 +1,0 @@
-// format: off
-// DO NOT EDIT! This file is auto-generated.
-
-// This file enables sbt-bloop to create bloop config files.
-
-addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "2.0.13")
-addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.6.2")
-
-// format: on

--- a/project/project/metals.sbt
+++ b/project/project/metals.sbt
@@ -1,8 +1,0 @@
-// format: off
-// DO NOT EDIT! This file is auto-generated.
-
-// This file enables sbt-bloop to create bloop config files.
-
-addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "2.0.13")
-
-// format: on

--- a/project/project/project/metals.sbt
+++ b/project/project/project/metals.sbt
@@ -1,8 +1,0 @@
-// format: off
-// DO NOT EDIT! This file is auto-generated.
-
-// This file enables sbt-bloop to create bloop config files.
-
-addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "2.0.13")
-
-// format: on


### PR DESCRIPTION
These files were accidentally committed and should not be tracked by git. 
We should remove them as they create merge conflicts. 