### PR TITLE
Remove shape checks

### DIFF
--- a/core/src/main/scala/dimwit/jax/Jax.scala
+++ b/core/src/main/scala/dimwit/jax/Jax.scala
@@ -6,6 +6,9 @@ import me.shadaj.scalapy.py.PyQuote
 
 object Jax:
 
+  private[dimwit] val ArrayTypeName = "ArrayImpl"
+  private[dimwit] val BatchTracerName = "BatchTracer"
+
   type PyAny = py.Any
   type PyDynamic = py.Dynamic
 
@@ -27,8 +30,10 @@ object Jax:
 
   def devices(deviceType: String): Seq[py.Dynamic] =
     val jaxModule = py.module("jax")
-    val devices = jaxModule.devices(deviceType)
-    devices.as[Seq[py.Dynamic]]
+    try
+      val devices = jaxModule.devices(deviceType)
+      devices.as[Seq[py.Dynamic]]
+    catch case e: me.shadaj.scalapy.py.PythonException => Seq.empty
 
   def device_put(x: py.Dynamic, device: PyDynamic): PyDynamic =
     val jaxModule = py.module("jax")

--- a/core/src/main/scala/dimwit/tensor/Shape.scala
+++ b/core/src/main/scala/dimwit/tensor/Shape.scala
@@ -13,14 +13,6 @@ final case class Shape[+T <: Tuple: Labels] @publicInBinary private (
 
   lazy val labels: List[String] = summon[Labels[T]].names
 
-  require(
-    dimensions.size == labels.size,
-    s"Dimensions and labels must have the same size but got ${dimensions.size} dims and ${labels.size} labels, dimensions: $dimensions, labels: ${labels.mkString(", ")}"
-  )
-  require(dimensions.forall(_ > 0), "All dimensions must be positive")
-  // TODO maybe same Axis must means symetric along these axes? => same length
-  // require(labels.distinct.size == labels.size, "Labels must be unique")
-
   def rank: Int = dimensions.size
   def size: Int = dimensions.foldLeft(1)((acc, d) => acc * d.asInstanceOf[Int])
   def dim[L](axis: Axis[L])(using axisIndex: AxisIndex[T @uncheckedVariance, L]): Dim[L] = axis -> this(axis)

--- a/core/src/main/scala/dimwit/tensor/TensorOps.scala
+++ b/core/src/main/scala/dimwit/tensor/TensorOps.scala
@@ -828,7 +828,7 @@ object TensorOps:
       ): Tensor[L *: OutShape, OutV] =
         // allows us to ignore labels for the intermediate sliced tensors
         val dummyLabels = new Labels[Nothing]:
-          val names = "dummy" :: Nil
+          val names = Nil
 
         val fpy = (args: py.Dynamic) =>
           val tensorList = args.as[Seq[py.Dynamic]].zipWithIndex.map { (jaxArr, i) =>

--- a/examples/src/main/scala/basic/Playground.scala
+++ b/examples/src/main/scala/basic/Playground.scala
@@ -237,11 +237,17 @@ trait C derives Label
     )
     val x2 = Tensor.ones(
       Shape(
-        Axis[B] -> 1,
+        Axis[B] -> 4,
         Axis[C] -> 2
       ),
       VType[Float]
     )
+    println("vmap - println in vmap")
+    val res = x2.vmap(Axis[B]) { xi2 =>
+      println(s"\t ${xi2}")
+      xi2
+    }
+    println(res)
   }
   {
     def f[L1: Label, L2: Label, L3: Label, V](x: Tensor[(L1, L2), Float], y: Tensor[(L2, L3), Float]) =


### PR DESCRIPTION
We had several require checks in shape which
1. Did most of the time not trigger as shape is lazy val in tensor
2. Lead to wrong errors if made eager as jaxValue is not always a concrete Array, e.g. BatchTracer

Given this the best course of action was to remove the requires. They were initially added to fail fast in case of label tracking, however due to 1. this never really materialized.

The insight of jaxValues not always being concrete Arrays lead to additional clean-up changes in this commit:

1. Addition of a jaxTypeName to make Tensor aware of its underlying jaxValue
2. Implement smarter toString given this jaxTypeName.

Furthermore the Device class lead to an error on non-CUDA devices. I changed it to not longer fail. The current Device enum is however rather pourly designed and must be overhauled in a future commit/PR.