### PR TITLE
improve error message when a label instance is not available

### DIFF
--- a/core/src/main/scala/dimwit/tensor/Labels.scala
+++ b/core/src/main/scala/dimwit/tensor/Labels.scala
@@ -5,9 +5,7 @@ import scala.quoted.*
 
 @scala.annotation.implicitNotFound("""
 An axis label ${T} was given or inferred, which does not have a Label instance.
-Ensure that:
-1. All axis types ${T} are defined with 'derives Label' (e.g. 'trait T derives Label'), or
-2. You are not accidentally mixing incompatible label types (these would be unified by the compiler to a new type, which does not have a Label instance.
+Ensure that all axis types ${T} are defined with 'derives Label' (e.g. 'trait T derives Label')
 """)
 trait Label[T]:
   def name: String
@@ -27,9 +25,7 @@ object Label:
 @scala.annotation.implicitNotFound("""
 A tuple of axis labels ${T} was given or inferred that does not have a valid Labels instance. 
 
-Common causes:
-- One of the types in the tuple is missing a 'derives Label' clause.
-- You are mixing incompatible label types, which the compiler automatically unifies to a new type, which may not have a Labels instance.
+Ensure that all of the types in the tuple have a 'derives Label' clause.
 """)
 trait Labels[T]:
   def names: List[String]


### PR DESCRIPTION
Making mistakes with the labels can lead to nasty error messages in dimwit, which are extremely hard to pinpoint, as the resulting type is often computed and, thanks to type inference, not seen directly in the code. 

As an example, consider the following code
```
  trait Base derives Label
  trait Target derives Label

  val dist  = Normal(
    Tensor(
      Shape(Axis[Target] -> 2)
    ).fill(2f),
    Tensor(
      Shape(Axis[Target] -> 2, Axis[Target] -> 2)
    ).fromArray(
      Array(0.5f, 0f, 0f, 0.5f, 0.5f, 0f, 0f, 0.5f)
    )
  )
```
Here, the user provides a covariance matrix to an  independent normal distribution, instead of just the variances. From the error message it is almost impossible to infer the mistake. 

Given really targeted error messages would require adding explicit checks to all sites where several labels are used (which seems impractical).  This PR is a first attempt to provide at least a better general error message when something is wrong with the labels.