### PR TITLE
Remove subtype parameters in normal distribution

### DIFF
--- a/core/src/main/scala/dimwit/stats/IndependentDistributions.scala
+++ b/core/src/main/scala/dimwit/stats/IndependentDistributions.scala
@@ -8,9 +8,9 @@ import me.shadaj.scalapy.py
 import me.shadaj.scalapy.py.SeqConverters
 import dimwit.random.Random
 
-class Normal[T <: Tuple: Labels, LocT <: T, ScaleT <: T](
-    val loc: Tensor[LocT, Float],
-    val scale: Tensor[ScaleT, Float]
+class Normal[T <: Tuple: Labels](
+    val loc: Tensor[T, Float],
+    val scale: Tensor[T, Float]
 ) extends IndependentDistribution[T, Float]:
 
   require(loc.shape.dimensions == scale.shape.dimensions, "loc and scale must have the same dimensions")

--- a/core/src/test/scala/dimwit/stats/DistributionSuite.scala
+++ b/core/src/test/scala/dimwit/stats/DistributionSuite.scala
@@ -41,17 +41,6 @@ class DistributionSuite extends AnyFunSpec with Matchers:
       val expectedMeans = normal.loc
       sampleMeans should approxEqual(expectedMeans, 0.2f)
 
-    it("more specific types"):
-      trait A derives Label
-      trait LocA extends A derives Label
-      trait ScaleA extends A derives Label
-      val loc = Tensor(Shape(Axis[LocA] -> 3)).fromArray(Array(0.0f, 1.0f, -0.5f))
-      val scale = Tensor(Shape(Axis[ScaleA] -> 3)).fromArray(Array(1.0f, 0.5f, 2.0f))
-      val x = Tensor(Shape(Axis[A] -> 3)).fromArray(Array(0.5f, 1.5f, -1.0f))
-      val dist = Normal(loc, scale)
-      val scalaLogProbs = dist.logProb(x)
-      scalaLogProbs shouldBe a[Tensor1[A, LogProb]]
-
   describe("Uniform Distribution"):
     it("logProbs matches JAX"):
       val low = Tensor(Shape(Axis[A] -> 3)).fromArray(Array(0.0f, -1.0f, 2.0f))


### PR DESCRIPTION
The semantics (and need) for different subtypes of a type in the normal distribution is not clear. 
This PR removes it and thus simplifies the usage of the distribution. Error messages are now very clear when incompatible types are passed for mean and variance. 