### PR TITLE
Add Prime label for some cases where two labels are known to be the same

### DIFF
--- a/core/src/main/scala/dimwit/autodiff/Autodiff.scala
+++ b/core/src/main/scala/dimwit/autodiff/Autodiff.scala
@@ -1,6 +1,7 @@
 package dimwit.autodiff
 
 import dimwit.tensor.{Tensor, Tensor0, Tensor1, Tensor2, Shape, AxisIndices}
+import dimwit.tensor.TupleHelpers.PrimeConcatType
 import dimwit.jax.Jax
 import me.shadaj.scalapy.py
 import dimwit.tensor.Label
@@ -16,7 +17,7 @@ object Autodiff:
   type GradientTensorVsInput[In, OutShape <: Tuple, V] = In match
     case EmptyTuple      => EmptyTuple
     case h *: t          => GradientTensorVsInput[h, OutShape, V] *: GradientTensorVsInput[t, OutShape, V]
-    case Tensor[inS, v2] => Tensor[Tuple.Concat[OutShape, inS], V]
+    case Tensor[inS, v2] => Tensor[PrimeConcatType[OutShape, inS], V]
 
   // TODO replace with TupledFunction when available (no longer experimental)
   def grad[T1, T2, V](f: (T1, T2) => Tensor0[V])(using t1Tree: ToPyTree[T1], t2Tree: ToPyTree[T2], outTree: ToPyTree[Tensor0[V]]): (T1, T2) => Grad[(T1, T2)] = (t1, t2) => grad(f.tupled)((t1, t2))

--- a/core/src/main/scala/dimwit/tensor/Tensor.scala
+++ b/core/src/main/scala/dimwit/tensor/Tensor.scala
@@ -14,6 +14,7 @@ import me.shadaj.scalapy.readwrite.Writer
 import scala.reflect.ClassTag
 import scala.annotation.unchecked.uncheckedVariance
 import dimwit.stats.IndependentDistribution
+import dimwit.Prime
 
 enum Device(val platform: String):
   case CPU extends Device("cpu")
@@ -129,10 +130,10 @@ object Tensor2:
 
   def apply[L1: Label, L2: Label](axis1: Axis[L1], axis2: Axis[L2]): Tensor2.Factory[L1, L2] = Tensor2.Factory(axis1, axis2)
 
-  private def eyeImpl[L: Label, V](dim: AxisExtent[L], dtype: DType): Tensor2[L, L, V] = Tensor(Jax.jnp.eye(dim.size, dtype = dtype.jaxType))
-  def eye[L: Label](dim: AxisExtent[L])(using et: ExecutionType[Float]): Tensor2[L, L, Float] = eyeImpl(dim, et.dtype)
-  def eye[L: Label, V](dim: AxisExtent[L], vtype: VType[V]): Tensor2[L, L, V] = eyeImpl(dim, vtype.dtype)
-  def diag[L: Label, V](diag: Tensor1[L, V]): Tensor2[L, L, V] = Tensor(Jax.jnp.diag(diag.jaxValue))
+  private def eyeImpl[L: Label, V](dim: AxisExtent[L], dtype: DType): Tensor2[L, Prime[L], V] = Tensor(Jax.jnp.eye(dim.size, dtype = dtype.jaxType))
+  def eye[L: Label](dim: AxisExtent[L])(using et: ExecutionType[Float]): Tensor2[L, Prime[L], Float] = eyeImpl(dim, et.dtype)
+  def eye[L: Label, V](dim: AxisExtent[L], vtype: VType[V]): Tensor2[L, Prime[L], V] = eyeImpl(dim, vtype.dtype)
+  def diag[L: Label, V](diag: Tensor1[L, V]): Tensor2[L, Prime[L], V] = Tensor(Jax.jnp.diag(diag.jaxValue))
 
 object Tensor3:
 

--- a/core/src/main/scala/dimwit/tensor/TupleHelpers.scala
+++ b/core/src/main/scala/dimwit/tensor/TupleHelpers.scala
@@ -249,3 +249,14 @@ object TupleHelpers:
     ): PrimeConcat.Aux[R1, R2, Tuple.Concat[R1, Suffix]] =
       new PrimeConcat[R1, R2]:
         type Out = Tuple.Concat[R1, Suffix]
+
+  // Match type versions for compile-time reduction
+  // PrimeRest: Transform tuple elements, adding Prime[H] if H is in Fixed
+  type PrimeRestType[Fixed <: Tuple, Incoming <: Tuple] <: Tuple = Incoming match
+    case EmptyTuple => EmptyTuple
+    case h *: t     => Member[h, Fixed] match
+        case true  => Prime[h] *: PrimeRestType[Fixed, t]
+        case false => h *: PrimeRestType[Fixed, t]
+
+  // PrimeConcat: Concatenate R1 with primed version of R2
+  type PrimeConcatType[R1 <: Tuple, R2 <: Tuple] = Tuple.Concat[R1, PrimeRestType[R1, R2]]


### PR DESCRIPTION
We started going the route that when we have two labels `L` that are the same, we are going to disambiguate by adding `Prime` to it and get `Prime[L]` as an label for the second axis. This is already enforced in the covariance matrix of the MVNormal distribution. 

If we are serious about it, then we also need to make sure other methods have the same behavior. For example, if we want to build a covariance matrix using `eye(Axis[L]->3)` this should then return a `Tensor2[L, Prime[L]`. Similar issues can arise when we compute a Jacobian matrix. This PR goes a first step into the direction of adding more `Prime` labels for consistency. 

