### PR TITLE
Add OnError to track errors in traced scala code

### DIFF
--- a/core/src/main/scala/dimwit/OnError.scala
+++ b/core/src/main/scala/dimwit/OnError.scala
@@ -1,0 +1,38 @@
+package dimwit
+
+import java.io.StringWriter
+import java.io.PrintWriter
+
+object OnError:
+
+  private val TraceHeader = "🛑 SCALA ERROR"
+
+  private val niceErrorMessage: Boolean = sys.env.getOrElse("DimWitNiceErrorMessages", "enabled") == "enabled"
+
+  /** In tracer blocks (e.g., jit, grad, vmap) the original scala error stack is lost in PythonException.
+    * This utility captures the scala stack trace at the first exception and re-throws a cleaned up version.
+    *
+    * @param block
+    * @return
+    */
+  def traceStack[T](block: => T): T =
+    try
+      block
+    catch
+      case e: Throwable if e.getMessage != null && e.getMessage.contains(TraceHeader) =>
+        // Already traced => re-throw original error
+        throw e
+      case e: Throwable if niceErrorMessage =>
+        // First time error - capture and re-throw with cleaned stack trace
+        val sw = new StringWriter()
+        e.printStackTrace(new PrintWriter(sw))
+        val cleanTrace = sw.toString.linesIterator
+          .filterNot(_.contains("me.shadaj.scalapy"))
+          .filterNot(_.contains("com.sun.jna."))
+          .filterNot(_.contains("java.base/jdk.internal."))
+          .filterNot(_.contains("java.base/java.lang"))
+          .mkString("\n")
+        val Prefix = f"\n****\n* $TraceHeader:\n***\n"
+        val Postfix = "\n****\n* END SCALA ERROR\n***\n"
+        throw RuntimeException(s"$Prefix $cleanTrace $Postfix")
+      case e => throw e

--- a/core/src/main/scala/dimwit/autodiff/Autodiff.scala
+++ b/core/src/main/scala/dimwit/autodiff/Autodiff.scala
@@ -1,5 +1,6 @@
 package dimwit.autodiff
 
+import dimwit.OnError
 import dimwit.tensor.{Tensor, Tensor0, Tensor1, Tensor2, Shape, AxisIndices}
 import dimwit.tensor.TupleHelpers.PrimeConcatType
 import dimwit.jax.Jax
@@ -29,8 +30,9 @@ object Autodiff:
   ): Input => Grad[Input] =
 
     val fpy = (jxpr: py.Dynamic) =>
-      val x = inTree.fromPyTree(jxpr)
-      outTree.toPyTree(f(x))
+      OnError.traceStack:
+        val x = inTree.fromPyTree(jxpr)
+        outTree.toPyTree(f(x))
 
     val gpy = Jax.jax_helper.grad(fpy)
 
@@ -46,8 +48,9 @@ object Autodiff:
   ): In => Gradient[In, Out] =
 
     val fpy = (jxpr: py.Dynamic) =>
-      val x = inTree.fromPyTree(jxpr)
-      outTree.toPyTree(f(x))
+      OnError.traceStack:
+        val x = inTree.fromPyTree(jxpr)
+        outTree.toPyTree(f(x))
 
     val jpy = Jax.jax_helper.jacobian(fpy)
 
@@ -61,7 +64,9 @@ object Autodiff:
       outTree: ToPyTree[Out],
       gradTree: ToPyTree[Gradient[In, Out]]
   ): In => Gradient[In, Out] =
-    val fpy = (jxpr: py.Dynamic) => outTree.toPyTree(f(inTree.fromPyTree(jxpr)))
+    val fpy = (jxpr: py.Dynamic) =>
+      OnError.traceStack:
+        outTree.toPyTree(f(inTree.fromPyTree(jxpr)))
     val jpy = Jax.jax_helper.jacrev(fpy)
     (params: In) => gradTree.fromPyTree(jpy(inTree.toPyTree(params)))
 
@@ -70,6 +75,8 @@ object Autodiff:
       outTree: ToPyTree[Out],
       gradTree: ToPyTree[Gradient[In, Out]]
   ): In => Gradient[In, Out] =
-    val fpy = (jxpr: py.Dynamic) => outTree.toPyTree(f(inTree.fromPyTree(jxpr)))
+    val fpy = (jxpr: py.Dynamic) =>
+      OnError.traceStack:
+        outTree.toPyTree(f(inTree.fromPyTree(jxpr)))
     val jpy = Jax.jax_helper.jacfwd(fpy)
     (params: In) => gradTree.fromPyTree(jpy(inTree.toPyTree(params)))

--- a/core/src/main/scala/dimwit/jax/Jit.scala
+++ b/core/src/main/scala/dimwit/jax/Jit.scala
@@ -6,6 +6,8 @@ import dimwit.autodiff.ToPyTree
 import me.shadaj.scalapy.py
 import me.shadaj.scalapy.py.SeqConverters
 import dimwit.jax.Jax.PyDynamic
+import me.shadaj.scalapy.py.PythonException
+import dimwit.OnError
 
 object Jit:
 
@@ -46,9 +48,10 @@ private object JitInternal:
   def toPyJit[T: ToPyTree, R: ToPyTree](f: T => R, pyKwargs: Map[String, Any]): T => R =
 
     val fpy = (pyTreePy: Jax.PyDynamic) =>
-      val pyTree = ToPyTree[T].fromPyTree(pyTreePy)
-      val result = f(pyTree)
-      ToPyTree[R].toPyTree(result)
+      OnError.traceStack:
+        val pyTree = ToPyTree[T].fromPyTree(pyTreePy)
+        val result = f(pyTree)
+        ToPyTree[R].toPyTree(result)
 
     val jitted = pyJit(fpy, Map.empty)
 
@@ -59,10 +62,11 @@ private object JitInternal:
 
   def toPyJit[T1: ToPyTree, T2: ToPyTree, R: ToPyTree](f: (T1, T2) => R, pyKwargs: Map[String, Any]): (T1, T2) => R =
     val fpy = (t1: Jax.PyDynamic, t2: Jax.PyDynamic) =>
-      val pyT1 = ToPyTree[T1].fromPyTree(t1)
-      val pyT2 = ToPyTree[T2].fromPyTree(t2)
-      val result = f(pyT1, pyT2)
-      ToPyTree[R].toPyTree(result)
+      OnError.traceStack:
+        val pyT1 = ToPyTree[T1].fromPyTree(t1)
+        val pyT2 = ToPyTree[T2].fromPyTree(t2)
+        val result = f(pyT1, pyT2)
+        ToPyTree[R].toPyTree(result)
 
     val jitted = pyJit(fpy, pyKwargs)
 
@@ -74,11 +78,12 @@ private object JitInternal:
 
   def toPyJit[T1: ToPyTree, T2: ToPyTree, T3: ToPyTree, R: ToPyTree](f: (T1, T2, T3) => R, pyKwargs: Map[String, Any]): (T1, T2, T3) => R =
     val fpy = (t1: Jax.PyDynamic, t2: Jax.PyDynamic, t3: Jax.PyDynamic) =>
-      val pyT1 = ToPyTree[T1].fromPyTree(t1)
-      val pyT2 = ToPyTree[T2].fromPyTree(t2)
-      val pyT3 = ToPyTree[T3].fromPyTree(t3)
-      val result = f(pyT1, pyT2, pyT3)
-      ToPyTree[R].toPyTree(result)
+      OnError.traceStack:
+        val pyT1 = ToPyTree[T1].fromPyTree(t1)
+        val pyT2 = ToPyTree[T2].fromPyTree(t2)
+        val pyT3 = ToPyTree[T3].fromPyTree(t3)
+        val result = f(pyT1, pyT2, pyT3)
+        ToPyTree[R].toPyTree(result)
 
     val jitted = pyJit(fpy, pyKwargs)
 
@@ -91,12 +96,13 @@ private object JitInternal:
 
   def toPyJit[T1: ToPyTree, T2: ToPyTree, T3: ToPyTree, T4: ToPyTree, R: ToPyTree](f: (T1, T2, T3, T4) => R, pyKwargs: Map[String, Any]): (T1, T2, T3, T4) => R =
     val fpy = (t1: Jax.PyDynamic, t2: Jax.PyDynamic, t3: Jax.PyDynamic, t4: Jax.PyDynamic) =>
-      val pyT1 = ToPyTree[T1].fromPyTree(t1)
-      val pyT2 = ToPyTree[T2].fromPyTree(t2)
-      val pyT3 = ToPyTree[T3].fromPyTree(t3)
-      val pyT4 = ToPyTree[T4].fromPyTree(t4)
-      val result = f(pyT1, pyT2, pyT3, pyT4)
-      ToPyTree[R].toPyTree(result)
+      OnError.traceStack:
+        val pyT1 = ToPyTree[T1].fromPyTree(t1)
+        val pyT2 = ToPyTree[T2].fromPyTree(t2)
+        val pyT3 = ToPyTree[T3].fromPyTree(t3)
+        val pyT4 = ToPyTree[T4].fromPyTree(t4)
+        val result = f(pyT1, pyT2, pyT3, pyT4)
+        ToPyTree[R].toPyTree(result)
 
     val jitted = pyJit(fpy, pyKwargs)
 
@@ -147,19 +153,21 @@ object JitDonating:
 
   case class JitReducer1[R: ToPyTree](f: R => R) extends (Donatable => Donatable) with JitReducer[R]:
     val fpy = (r: Donatable) =>
-      val rPy = ToPyTree[R].fromPyTree(r)
-      val result = f(rPy)
-      ToPyTree[R].toPyTree(result)
+      OnError.traceStack:
+        val rPy = ToPyTree[R].fromPyTree(r)
+        val result = f(rPy)
+        ToPyTree[R].toPyTree(result)
     val jitted = pyJit(fpy, Map("donate_argnums" -> Tuple1(0)))
     def apply(r: Donatable): Donatable =
       jitted(r)
 
   case class JitReducer2[R: ToPyTree, T1: ToPyTree](f: (T1, R) => R) extends JitReducer[R]:
     val fpy = (t1: Jax.PyDynamic, r: Donatable) =>
-      val pyT1 = ToPyTree[T1].fromPyTree(t1)
-      val rPy = ToPyTree[R].fromPyTree(r)
-      val result = f(pyT1, rPy)
-      ToPyTree[R].toPyTree(result)
+      OnError.traceStack:
+        val pyT1 = ToPyTree[T1].fromPyTree(t1)
+        val rPy = ToPyTree[R].fromPyTree(r)
+        val result = f(pyT1, rPy)
+        ToPyTree[R].toPyTree(result)
     val jitted = pyJit(fpy, Map("donate_argnums" -> Tuple1(1)))
     def apply(t1: T1)(r: Donatable): Donatable =
       val pyT1 = ToPyTree[T1].toPyTree(t1)
@@ -167,11 +175,12 @@ object JitDonating:
 
   case class JitReducer3[R: ToPyTree, T1: ToPyTree, T2: ToPyTree](f: (T1, T2, R) => R) extends JitReducer[R]:
     val fpy = (t1: Jax.PyDynamic, t2: Jax.PyDynamic, r: Donatable) =>
-      val pyT1 = ToPyTree[T1].fromPyTree(t1)
-      val pyT2 = ToPyTree[T2].fromPyTree(t2)
-      val rPy = ToPyTree[R].fromPyTree(r)
-      val result = f(pyT1, pyT2, rPy)
-      ToPyTree[R].toPyTree(result)
+      OnError.traceStack:
+        val pyT1 = ToPyTree[T1].fromPyTree(t1)
+        val pyT2 = ToPyTree[T2].fromPyTree(t2)
+        val rPy = ToPyTree[R].fromPyTree(r)
+        val result = f(pyT1, pyT2, rPy)
+        ToPyTree[R].toPyTree(result)
     val jitted = pyJit(fpy, Map("donate_argnums" -> Tuple1(2)))
     def apply(t1: T1, t2: T2)(r: Donatable): Donatable =
       val pyT1 = ToPyTree[T1].toPyTree(t1)
@@ -180,12 +189,13 @@ object JitDonating:
 
   case class JitReducer4[R: ToPyTree, T1: ToPyTree, T2: ToPyTree, T3: ToPyTree](f: (T1, T2, T3, R) => R) extends JitReducer[R]:
     val fpy = (t1: Jax.PyDynamic, t2: Jax.PyDynamic, t3: Jax.PyDynamic, r: Donatable) =>
-      val pyT1 = ToPyTree[T1].fromPyTree(t1)
-      val pyT2 = ToPyTree[T2].fromPyTree(t2)
-      val pyT3 = ToPyTree[T3].fromPyTree(t3)
-      val rPy = ToPyTree[R].fromPyTree(r)
-      val result = f(pyT1, pyT2, pyT3, rPy)
-      ToPyTree[R].toPyTree(result)
+      OnError.traceStack:
+        val pyT1 = ToPyTree[T1].fromPyTree(t1)
+        val pyT2 = ToPyTree[T2].fromPyTree(t2)
+        val pyT3 = ToPyTree[T3].fromPyTree(t3)
+        val rPy = ToPyTree[R].fromPyTree(r)
+        val result = f(pyT1, pyT2, pyT3, rPy)
+        ToPyTree[R].toPyTree(result)
     val jitted = pyJit(fpy, Map("donate_argnums" -> Tuple1(3)))
     def apply(t1: T1, t2: T2, t3: T3)(r: Donatable): Donatable =
       val pyT1 = ToPyTree[T1].toPyTree(t1)

--- a/core/src/main/scala/dimwit/tensor/Tensor.scala
+++ b/core/src/main/scala/dimwit/tensor/Tensor.scala
@@ -68,6 +68,9 @@ class Tensor[T <: Tuple: Labels, V] private[tensor] (
     shape.extent(axis)
 
   private val jaxTypeName: String = py.Dynamic.global.`type`(jaxValue).`__name__`.as[String]
+  lazy val isTracer: Boolean =
+    val jaxCoreTracer = py.module("jax.core").Tracer
+    py.Dynamic.global.isinstance(jaxValue, jaxCoreTracer).as[Boolean]
 
 object Tensor:
 


### PR DESCRIPTION
A step towards better error messages for errors in Scala code that is being traced by Python.

For example if I introduce an error in the ML example:

```scala
val targetLogit = logits.slice(Axis[L].at(label.item)) // item causes error in jit
```

Then the erroneous line does not show up in the old message but shows up in the new message.

Old:

```txt
[error] Exception in thread "main" me.shadaj.scalapy.py.PythonException: Traceback (most recent call last):
[error]   File "/var/folders/2t/3k3268jx7cb4t578qb3l1vwr0000gq/T/dimwit-python10448737475210435255/jax_helper.py", line 160, in python_wrapper
[error]     return f(*args, **kwargs)
[error]            ^^^^^^^^^^^^^^^^^^
[error] <class 'RuntimeError'> Traceback (most recent call last):
[error]   File "/Users/mebr/Documents/Privat/Projects/shapeful/.venv/lib/python3.12/site-packages/jax/_src/traceback_util.py", line 195, in reraise_with_filtered_traceback
[error]     return fun(*args, **kwargs)
[error]            ^^^^^^^^^^^^^^^^^^^^
[error]   File "/Users/mebr/Documents/Privat/Projects/shapeful/.venv/lib/python3.12/site-packages/jax/_src/api.py", line 473, in grad_f
[error]     _, g = value_and_grad_f(*args, **kwargs)
[error]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[error]   File "/Users/mebr/Documents/Privat/Projects/shapeful/.venv/lib/python3.12/site-packages/jax/_src/traceback_util.py", line 195, in reraise_with_filtered_traceback
[error]     return fun(*args, **kwargs)
[error]            ^^^^^^^^^^^^^^^^^^^^
[error]   File "/Users/mebr/Documents/Privat/Projects/shapeful/.venv/lib/python3.12/site-packages/jax/_src/api.py", line 547, in value_and_grad_f
[error]     ans, vjp_py = _vjp(f_partial, *dyn_args)
[error]                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
[error]   File "/Users/mebr/Documents/Privat/Projects/shapeful/.venv/lib/python3.12/site-packages/jax/_src/api.py", line 2228, in _vjp
[error]     return _vjp3(fun, *primals, has_aux=has_aux)
[error]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[error]   File "/Users/mebr/Documents/Privat/Projects/shapeful/.venv/lib/python3.12/site-packages/jax/_src/api.py", line 2341, in _vjp3
[error]     out_primals_flat, out_pvals, jaxpr, residuals = ad.linearize(
[error]                                                     ^^^^^^^^^^^^^
[error]   File "/Users/mebr/Documents/Privat/Projects/shapeful/.venv/lib/python3.12/site-packages/jax/_src/interpreters/ad.py", line 287, in linearize
[error]     return direct_linearize(traceable, primals, kwargs, has_aux=has_aux)
[error]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[error]   File "/Users/mebr/Documents/Privat/Projects/shapeful/.venv/lib/python3.12/site-packages/jax/_src/interpreters/ad.py", line 261, in direct_linearize
[error]     ans = traceable.call_wrapped(*tracers)
[error]           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[error]   File "/Users/mebr/Documents/Privat/Projects/shapeful/.venv/lib/python3.12/site-packages/jax/_src/linear_util.py", line 212, in call_wrapped
[error]     return self.f_transformed(*args, **kwargs)
[error]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[error]   File "/Users/mebr/Documents/Privat/Projects/shapeful/.venv/lib/python3.12/site-packages/jax/_src/api_util.py", line 90, in flatten_fun_nokwargs
[error]     ans = f(*py_args)
[error]           ^^^^^^^^^^^
[error]   File "/Users/mebr/Documents/Privat/Projects/shapeful/.venv/lib/python3.12/site-packages/jax/_src/api_util.py", line 292, in _argnums_partial
[error]     return _fun(*args, **kwargs)
[error]            ^^^^^^^^^^^^^^^^^^^^^
[error]   File "/Users/mebr/Documents/Privat/Projects/shapeful/.venv/lib/python3.12/site-packages/jax/_src/linear_util.py", line 421, in _get_result_paths_thunk
[error]     ans = _fun(*args, **kwargs)
[error]           ^^^^^^^^^^^^^^^^^^^^^
[error]   File "/var/folders/2t/3k3268jx7cb4t578qb3l1vwr0000gq/T/dimwit-python10448737475210435255/jax_helper.py", line 87, in python_wrapper
[error]     return f(*args)
[error]            ^^^^^^^^
[error] <class 'RuntimeError'> Traceback (most recent call last):
[error]   File "/var/folders/2t/3k3268jx7cb4t578qb3l1vwr0000gq/T/dimwit-python10448737475210435255/jax_helper.py", line 27, in <lambda>
[error]     return lambda jax_inputs_tuple: jax.vmap(python_wrapper, in_axes=dims)(*jax_inputs_tuple)
[error]                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[error]   File "/Users/mebr/Documents/Privat/Projects/shapeful/.venv/lib/python3.12/site-packages/jax/_src/traceback_util.py", line 195, in reraise_with_filtered_traceback
[error]     return fun(*args, **kwargs)
[error]            ^^^^^^^^^^^^^^^^^^^^
[error]   File "/Users/mebr/Documents/Privat/Projects/shapeful/.venv/lib/python3.12/site-packages/jax/_src/api.py", line 1204, in vmap_f
[error]     out_flat = batching.batch(
[error]                ^^^^^^^^^^^^^^^
[error]   File "/Users/mebr/Documents/Privat/Projects/shapeful/.venv/lib/python3.12/site-packages/jax/_src/linear_util.py", line 212, in call_wrapped
[error]     return self.f_transformed(*args, **kwargs)
[error]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[error]   File "/Users/mebr/Documents/Privat/Projects/shapeful/.venv/lib/python3.12/site-packages/jax/_src/interpreters/batching.py", line 645, in _batch_outer
[error]     outs, trace = f(tag, in_dims, *in_vals)
[error]                   ^^^^^^^^^^^^^^^^^^^^^^^^^
[error]   File "/Users/mebr/Documents/Privat/Projects/shapeful/.venv/lib/python3.12/site-packages/jax/_src/interpreters/batching.py", line 664, in _batch_inner
[error]     outs = f(*in_tracers)
[error]            ^^^^^^^^^^^^^^
[error]   File "/Users/mebr/Documents/Privat/Projects/shapeful/.venv/lib/python3.12/site-packages/jax/_src/interpreters/batching.py", line 342, in flatten_fun_for_vmap
[error]     ans = f(*py_args, **py_kwargs)
[error]           ^^^^^^^^^^^^^^^^^^^^^^^^
[error]   File "/Users/mebr/Documents/Privat/Projects/shapeful/.venv/lib/python3.12/site-packages/jax/_src/linear_util.py", line 421, in _get_result_paths_thunk
[error]     ans = _fun(*args, **kwargs)
[error]           ^^^^^^^^^^^^^^^^^^^^^
[error]   File "/var/folders/2t/3k3268jx7cb4t578qb3l1vwr0000gq/T/dimwit-python10448737475210435255/jax_helper.py", line 26, in python_wrapper
[error]     return f(args)
[error]            ^^^^^^^
[error] <class 'RuntimeError'> Traceback (most recent call last):
[error]   File "/Users/mebr/Documents/Privat/Projects/shapeful/.venv/lib/python3.12/site-packages/jax/_src/numpy/array_methods.py", line 1151, in meth
[error]     return getattr(self.aval, name).fun(self, *args, **kwargs)
[error]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[error]   File "/Users/mebr/Documents/Privat/Projects/shapeful/.venv/lib/python3.12/site-packages/jax/_src/numpy/array_methods.py", line 216, in _item
[error]     arr = core.concrete_or_error(np.asarray, self, context="This occurred in the item() method of jax.Array")
[error]           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[error]   File "/Users/mebr/Documents/Privat/Projects/shapeful/.venv/lib/python3.12/site-packages/jax/_src/core.py", line 1847, in concrete_or_error
[error]     raise ConcretizationTypeError(val, context)
[error] <class 'jax.errors.ConcretizationTypeError'> Abstract tracer value encountered where concrete value is expected: traced array with shape int8[]
[error] This occurred in the item() method of jax.Array
[error] This BatchTracer with object id 5091415664 was created on line:
[error]   /var/folders/2t/3k3268jx7cb4t578qb3l1vwr0000gq/T/dimwit-python10448737475210435255/jax_helper.py:27:36 (zipvmap.<locals>.<lambda>)
[error] See https://docs.jax.dev/en/latest/errors.html#jax.errors.ConcretizationTypeError
[error]         at me.shadaj.scalapy.interpreter.CPythonInterpreter$.throwErrorIfOccured$$anonfun$1$$anonfun$1(CPythonInterpreter.scala:390)
[error]         at me.shadaj.scalapy.interpreter.Platform$.Zone(Platform.scala:10)
[error]         at me.shadaj.scalapy.interpreter.CPythonInterpreter$.throwErrorIfOccured$$anonfun$1(CPythonInterpreter.scala:390)
[error]         at me.shadaj.scalapy.interpreter.CPythonInterpreter$.throwErrorIfOccured$$anonfun$adapted$1(CPythonInterpreter.scala:393)
[error]         at me.shadaj.scalapy.interpreter.CPythonInterpreter$.withGil(CPythonInterpreter.scala:161)
[error]         at me.shadaj.scalapy.interpreter.CPythonInterpreter$.throwErrorIfOccured(CPythonInterpreter.scala:393)
[error]         at me.shadaj.scalapy.interpreter.CPythonInterpreter$.runCallableAndDecref$$anonfun$1(CPythonInterpreter.scala:498)
[error]         at me.shadaj.scalapy.interpreter.CPythonInterpreter$.withGil(CPythonInterpreter.scala:161)
[error]         at me.shadaj.scalapy.interpreter.CPythonInterpreter$.runCallableAndDecref(CPythonInterpreter.scala:505)
[error]         at me.shadaj.scalapy.interpreter.CPythonInterpreter$.call$$anonfun$2(CPythonInterpreter.scala:547)
[error]         at me.shadaj.scalapy.interpreter.CPythonInterpreter$.withGil(CPythonInterpreter.scala:161)
[error]         at me.shadaj.scalapy.interpreter.CPythonInterpreter$.call(CPythonInterpreter.scala:548)
[error]         at me.shadaj.scalapy.py.AnyDynamics.apply(AnyDynamics.scala:10)
[error]         at me.shadaj.scalapy.py.AnyDynamics.apply$(AnyDynamics.scala:7)
[error]         at me.shadaj.scalapy.py.Dynamic.apply(Dynamic.scala:5)
[error]         at dimwit.jax.JitInternal$.toPyJit$$anonfun$4(Jit.scala:108)
[error]         at examples.basic.MLPClassifierMNist$.miniBatchGradientDescent$1$$anonfun$1(MLClassifierMNist.scala:127)
[error]         at scala.collection.LinearSeqOps.foldLeft(LinearSeq.scala:183)
[error]         at scala.collection.LinearSeqOps.foldLeft$(LinearSeq.scala:179)
[error]         at scala.collection.immutable.List.foldLeft(List.scala:79)
[error]         at examples.basic.MLPClassifierMNist$.miniBatchGradientDescent$1(MLClassifierMNist.scala:126)
[error]         at examples.basic.MLPClassifierMNist$.$anonfun$19(MLClassifierMNist.scala:129)
[error]         at examples.basic.MLPClassifierMNist$.$anonfun$21$$anonfun$1(MLClassifierMNist.scala:136)
[error]         at examples.package$package$.timed(package.scala:5)
[error]         at examples.basic.MLPClassifierMNist$.$anonfun$21(MLClassifierMNist.scala:136)
[error]         at scala.collection.Iterator$$anon$26.next(Iterator.scala:1109)
[error]         at scala.collection.Iterator$$anon$16.next(Iterator.scala:825)
[error]         at scala.collection.Iterator$$anon$16.next(Iterator.scala:820)
[error]         at scala.collection.Iterator$$anon$18.next(Iterator.scala:951)
[error]         at scala.collection.Iterator$SliceIterator.skip(Iterator.scala:1226)
[error]         at scala.collection.Iterator$SliceIterator.next(Iterator.scala:1242)
[error]         at examples.basic.MLPClassifierMNist$.main(MLClassifierMNist.scala:159)
[error]         at examples.basic.MLPClassifierMNist.main(MLClassifierMNist.scala)
[error] nonzero exit code returned from runner: 1
[error] (examples / Compile / run) nonzero exit code returned from runner: 1
[error] Total time: 27 s, completed 22 Jan 2026, 11:41:49
```

New:

```txt
[error] Exception in thread "main" me.shadaj.scalapy.py.PythonException: Traceback (most recent call last):
[error]   File "/var/folders/2t/3k3268jx7cb4t578qb3l1vwr0000gq/T/dimwit-python170108293197304700/jax_helper.py", line 160, in python_wrapper
[error]     return f(*args, **kwargs)
[error]            ^^^^^^^^^^^^^^^^^^
[error] <class 'RuntimeError'> Traceback (most recent call last):
[error]   File "/Users/mebr/Documents/Privat/Projects/shapeful/.venv/lib/python3.12/site-packages/jax/_src/traceback_util.py", line 195, in reraise_with_filtered_traceback
[error]     return fun(*args, **kwargs)
[error]            ^^^^^^^^^^^^^^^^^^^^
[error]   File "/Users/mebr/Documents/Privat/Projects/shapeful/.venv/lib/python3.12/site-packages/jax/_src/api.py", line 473, in grad_f
[error]     _, g = value_and_grad_f(*args, **kwargs)
[error]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[error]   File "/Users/mebr/Documents/Privat/Projects/shapeful/.venv/lib/python3.12/site-packages/jax/_src/traceback_util.py", line 195, in reraise_with_filtered_traceback
[error]     return fun(*args, **kwargs)
[error]            ^^^^^^^^^^^^^^^^^^^^
[error]   File "/Users/mebr/Documents/Privat/Projects/shapeful/.venv/lib/python3.12/site-packages/jax/_src/api.py", line 547, in value_and_grad_f
[error]     ans, vjp_py = _vjp(f_partial, *dyn_args)
[error]                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
[error]   File "/Users/mebr/Documents/Privat/Projects/shapeful/.venv/lib/python3.12/site-packages/jax/_src/api.py", line 2228, in _vjp
[error]     return _vjp3(fun, *primals, has_aux=has_aux)
[error]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[error]   File "/Users/mebr/Documents/Privat/Projects/shapeful/.venv/lib/python3.12/site-packages/jax/_src/api.py", line 2341, in _vjp3
[error]     out_primals_flat, out_pvals, jaxpr, residuals = ad.linearize(
[error]                                                     ^^^^^^^^^^^^^
[error]   File "/Users/mebr/Documents/Privat/Projects/shapeful/.venv/lib/python3.12/site-packages/jax/_src/interpreters/ad.py", line 287, in linearize
[error]     return direct_linearize(traceable, primals, kwargs, has_aux=has_aux)
[error]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[error]   File "/Users/mebr/Documents/Privat/Projects/shapeful/.venv/lib/python3.12/site-packages/jax/_src/interpreters/ad.py", line 261, in direct_linearize
[error]     ans = traceable.call_wrapped(*tracers)
[error]           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[error]   File "/Users/mebr/Documents/Privat/Projects/shapeful/.venv/lib/python3.12/site-packages/jax/_src/linear_util.py", line 212, in call_wrapped
[error]     return self.f_transformed(*args, **kwargs)
[error]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[error]   File "/Users/mebr/Documents/Privat/Projects/shapeful/.venv/lib/python3.12/site-packages/jax/_src/api_util.py", line 90, in flatten_fun_nokwargs
[error]     ans = f(*py_args)
[error]           ^^^^^^^^^^^
[error]   File "/Users/mebr/Documents/Privat/Projects/shapeful/.venv/lib/python3.12/site-packages/jax/_src/api_util.py", line 292, in _argnums_partial
[error]     return _fun(*args, **kwargs)
[error]            ^^^^^^^^^^^^^^^^^^^^^
[error]   File "/Users/mebr/Documents/Privat/Projects/shapeful/.venv/lib/python3.12/site-packages/jax/_src/linear_util.py", line 421, in _get_result_paths_thunk
[error]     ans = _fun(*args, **kwargs)
[error]           ^^^^^^^^^^^^^^^^^^^^^
[error]   File "/var/folders/2t/3k3268jx7cb4t578qb3l1vwr0000gq/T/dimwit-python170108293197304700/jax_helper.py", line 87, in python_wrapper
[error]     return f(*args)
[error]            ^^^^^^^^
[error] <class 'RuntimeError'> Traceback (most recent call last):
[error]   File "/var/folders/2t/3k3268jx7cb4t578qb3l1vwr0000gq/T/dimwit-python170108293197304700/jax_helper.py", line 27, in <lambda>
[error]     return lambda jax_inputs_tuple: jax.vmap(python_wrapper, in_axes=dims)(*jax_inputs_tuple)
[error]                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[error]   File "/Users/mebr/Documents/Privat/Projects/shapeful/.venv/lib/python3.12/site-packages/jax/_src/traceback_util.py", line 195, in reraise_with_filtered_traceback
[error]     return fun(*args, **kwargs)
[error]            ^^^^^^^^^^^^^^^^^^^^
[error]   File "/Users/mebr/Documents/Privat/Projects/shapeful/.venv/lib/python3.12/site-packages/jax/_src/api.py", line 1204, in vmap_f
[error]     out_flat = batching.batch(
[error]                ^^^^^^^^^^^^^^^
[error]   File "/Users/mebr/Documents/Privat/Projects/shapeful/.venv/lib/python3.12/site-packages/jax/_src/linear_util.py", line 212, in call_wrapped
[error]     return self.f_transformed(*args, **kwargs)
[error]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[error]   File "/Users/mebr/Documents/Privat/Projects/shapeful/.venv/lib/python3.12/site-packages/jax/_src/interpreters/batching.py", line 645, in _batch_outer
[error]     outs, trace = f(tag, in_dims, *in_vals)
[error]                   ^^^^^^^^^^^^^^^^^^^^^^^^^
[error]   File "/Users/mebr/Documents/Privat/Projects/shapeful/.venv/lib/python3.12/site-packages/jax/_src/interpreters/batching.py", line 664, in _batch_inner
[error]     outs = f(*in_tracers)
[error]            ^^^^^^^^^^^^^^
[error]   File "/Users/mebr/Documents/Privat/Projects/shapeful/.venv/lib/python3.12/site-packages/jax/_src/interpreters/batching.py", line 342, in flatten_fun_for_vmap
[error]     ans = f(*py_args, **py_kwargs)
[error]           ^^^^^^^^^^^^^^^^^^^^^^^^
[error]   File "/Users/mebr/Documents/Privat/Projects/shapeful/.venv/lib/python3.12/site-packages/jax/_src/linear_util.py", line 421, in _get_result_paths_thunk
[error]     ans = _fun(*args, **kwargs)
[error]           ^^^^^^^^^^^^^^^^^^^^^
[error]   File "/var/folders/2t/3k3268jx7cb4t578qb3l1vwr0000gq/T/dimwit-python170108293197304700/jax_helper.py", line 26, in python_wrapper
[error]     return f(args)
[error]            ^^^^^^^
[error] <class 'RuntimeError'> 
[error] ****
[error] * 🛑 SCALA ERROR:
[error] ***
[error]  java.lang.IllegalArgumentException: requirement failed: 
[error]  Cannot convert a JAX Tracer to a scalar value. Tensor0 is part of a JAX computation graph (e.g., inside vmap or a jitted function).
[error]  Common mistakes leading to this error:
[error]    - calling .slice(t0.item) rather than .slice(t0); breaking the computation graph unintentionally.
[error]         at scala.Predef$.require(Predef.scala:337)
[error]         at dimwit.tensor.TensorOps$Tensor0Ops$.item(TensorOps.scala:1078)
[error]         at dimwit.tensor.TensorOps$.item(TensorOps.scala:1116)
[error]         at dimwit.package$.item(package.scala:83)
[error]         at examples.basic.MLClassifierMNist$package$.binaryCrossEntropy(MLClassifierMNist.scala:20)
[error]         at examples.basic.MLPClassifierMNist$.$anonfun$1(MLClassifierMNist.scala:82)
[error]         at dimwit.tensor.TensorOps$.$anonfun$13$$anonfun$1(TensorOps.scala:981)
[error]         at dimwit.OnError$.traceStack(OnError.scala:18)
[error]         at dimwit.tensor.TensorOps$.dimwit$tensor$TensorOps$Functional$ZipVmap$$$_$_$$anonfun$13(TensorOps.scala:982)
[error]         at dimwit.tensor.TensorOps$Functional$ZipVmap$.zipvmap(TensorOps.scala:989)
[error]         at dimwit.tensor.TensorOps$Functional$.zipvmap(TensorOps.scala:993)
[error]         at dimwit.tensor.TensorOps$.zipvmap(TensorOps.scala:1062)
[error]         at dimwit.package$.zipvmap(package.scala:83)
[error]         at examples.basic.MLPClassifierMNist$.batchLoss$1(MLClassifierMNist.scala:82)
[error]         at examples.basic.MLPClassifierMNist$.$anonfun$3(MLClassifierMNist.scala:112)
[error]         at dimwit.autodiff.Autodiff$.$anonfun$2$$anonfun$1(Autodiff.scala:35)
[error]         at dimwit.OnError$.traceStack(OnError.scala:18)
[error]         at dimwit.autodiff.Autodiff$.$anonfun$2(Autodiff.scala:35)
[error]         at dimwit.autodiff.Autodiff$.grad$$anonfun$3(Autodiff.scala:41)
[error]         at examples.basic.MLPClassifierMNist$.gradientStep$1(MLClassifierMNist.scala:113)
[error]         at examples.basic.MLPClassifierMNist$.$anonfun$6(MLClassifierMNist.scala:115)
[error]         at dimwit.jax.JitInternal$.$anonfun$5$$anonfun$1(Jit.scala:101)
[error]         at dimwit.OnError$.traceStack(OnError.scala:18)
[error]         at dimwit.jax.JitInternal$.$anonfun$5(Jit.scala:102)
[error]         at dimwit.jax.JitInternal$.toPyJit$$anonfun$4(Jit.scala:111)
[error]         at examples.basic.MLPClassifierMNist$.miniBatchGradientDescent$1$$anonfun$1(MLClassifierMNist.scala:128)
[error]         at scala.collection.LinearSeqOps.foldLeft(LinearSeq.scala:183)
[error]         at scala.collection.LinearSeqOps.foldLeft$(LinearSeq.scala:179)
[error]         at scala.collection.immutable.List.foldLeft(List.scala:79)
[error]         at examples.basic.MLPClassifierMNist$.miniBatchGradientDescent$1(MLClassifierMNist.scala:127)
[error]         at examples.basic.MLPClassifierMNist$.$anonfun$19(MLClassifierMNist.scala:130)
[error]         at examples.basic.MLPClassifierMNist$.$anonfun$21$$anonfun$1(MLClassifierMNist.scala:137)
[error]         at examples.package$package$.timed(package.scala:5)
[error]         at examples.basic.MLPClassifierMNist$.$anonfun$21(MLClassifierMNist.scala:137)
[error]         at scala.collection.Iterator$$anon$26.next(Iterator.scala:1109)
[error]         at scala.collection.Iterator$$anon$16.next(Iterator.scala:825)
[error]         at scala.collection.Iterator$$anon$16.next(Iterator.scala:820)
[error]         at scala.collection.Iterator$$anon$18.next(Iterator.scala:951)
[error]         at scala.collection.Iterator$SliceIterator.skip(Iterator.scala:1226)
[error]         at scala.collection.Iterator$SliceIterator.next(Iterator.scala:1242)
[error]         at examples.basic.MLPClassifierMNist$.main(MLClassifierMNist.scala:160)
[error]         at examples.basic.MLPClassifierMNist.main(MLClassifierMNist.scala) 
[error] ****
[error] * END SCALA ERROR
[error] ***
[error]         at me.shadaj.scalapy.interpreter.CPythonInterpreter$.throwErrorIfOccured$$anonfun$1$$anonfun$1(CPythonInterpreter.scala:390)
[error]         at me.shadaj.scalapy.interpreter.Platform$.Zone(Platform.scala:10)
[error]         at me.shadaj.scalapy.interpreter.CPythonInterpreter$.throwErrorIfOccured$$anonfun$1(CPythonInterpreter.scala:390)
[error]         at me.shadaj.scalapy.interpreter.CPythonInterpreter$.throwErrorIfOccured$$anonfun$adapted$1(CPythonInterpreter.scala:393)
[error]         at me.shadaj.scalapy.interpreter.CPythonInterpreter$.withGil(CPythonInterpreter.scala:161)
[error]         at me.shadaj.scalapy.interpreter.CPythonInterpreter$.throwErrorIfOccured(CPythonInterpreter.scala:393)
[error]         at me.shadaj.scalapy.interpreter.CPythonInterpreter$.runCallableAndDecref$$anonfun$1(CPythonInterpreter.scala:498)
[error]         at me.shadaj.scalapy.interpreter.CPythonInterpreter$.withGil(CPythonInterpreter.scala:161)
[error]         at me.shadaj.scalapy.interpreter.CPythonInterpreter$.runCallableAndDecref(CPythonInterpreter.scala:505)
[error]         at me.shadaj.scalapy.interpreter.CPythonInterpreter$.call$$anonfun$2(CPythonInterpreter.scala:547)
[error]         at me.shadaj.scalapy.interpreter.CPythonInterpreter$.withGil(CPythonInterpreter.scala:161)
[error]         at me.shadaj.scalapy.interpreter.CPythonInterpreter$.call(CPythonInterpreter.scala:548)
[error]         at me.shadaj.scalapy.py.AnyDynamics.apply(AnyDynamics.scala:10)
[error]         at me.shadaj.scalapy.py.AnyDynamics.apply$(AnyDynamics.scala:7)
[error]         at me.shadaj.scalapy.py.Dynamic.apply(Dynamic.scala:5)
[error]         at dimwit.jax.JitInternal$.toPyJit$$anonfun$4(Jit.scala:111)
[error]         at examples.basic.MLPClassifierMNist$.miniBatchGradientDescent$1$$anonfun$1(MLClassifierMNist.scala:128)
[error]         at scala.collection.LinearSeqOps.foldLeft(LinearSeq.scala:183)
[error]         at scala.collection.LinearSeqOps.foldLeft$(LinearSeq.scala:179)
[error]         at scala.collection.immutable.List.foldLeft(List.scala:79)
[error]         at examples.basic.MLPClassifierMNist$.miniBatchGradientDescent$1(MLClassifierMNist.scala:127)
[error]         at examples.basic.MLPClassifierMNist$.$anonfun$19(MLClassifierMNist.scala:130)
[error]         at examples.basic.MLPClassifierMNist$.$anonfun$21$$anonfun$1(MLClassifierMNist.scala:137)
[error]         at examples.package$package$.timed(package.scala:5)
[error]         at examples.basic.MLPClassifierMNist$.$anonfun$21(MLClassifierMNist.scala:137)
[error]         at scala.collection.Iterator$$anon$26.next(Iterator.scala:1109)
[error]         at scala.collection.Iterator$$anon$16.next(Iterator.scala:825)
[error]         at scala.collection.Iterator$$anon$16.next(Iterator.scala:820)
[error]         at scala.collection.Iterator$$anon$18.next(Iterator.scala:951)
[error]         at scala.collection.Iterator$SliceIterator.skip(Iterator.scala:1226)
[error]         at scala.collection.Iterator$SliceIterator.next(Iterator.scala:1242)
[error]         at examples.basic.MLPClassifierMNist$.main(MLClassifierMNist.scala:160)
[error]         at examples.basic.MLPClassifierMNist.main(MLClassifierMNist.scala)
[error] nonzero exit code returned from runner: 1
[error] (examples / Compile / run) nonzero exit code returned from runner: 1
[error] Total time: 21 s, completed 22 Jan 2026, 10:12:11
```

---

This is achived by wrapping Scala function in a try catch and persisting stack trace (once) into the message.

Draft: We must include this everywhere (all jit, all diff, vmap, zipvmap) if we decide to go this route.