### PR TITLE
Refactor distribution hierarchy

### DIFF
--- a/core/src/main/scala/dimwit/package.scala
+++ b/core/src/main/scala/dimwit/package.scala
@@ -95,4 +95,4 @@ package object dimwit:
 
   // export some stats types
   export dimwit.stats.{Prob, LogProb}
-  export dimwit.stats.{Distribution, IndependentDistribution, MultivariateDistribution}
+  export dimwit.stats.{Distribution, IndependentDistribution, MultivariateDistribution, UnivariateDistribution}

--- a/core/src/main/scala/dimwit/package.scala
+++ b/core/src/main/scala/dimwit/package.scala
@@ -90,3 +90,10 @@ package object dimwit:
 
   object Conversions:
     export dimwit.tensor.Tensor0.{float2FloatTensor, int2IntTensor, int2FloatTensor, boolean2BooleanTensor}
+
+  // Export random object
+  export dimwit.random.Random
+
+  // export some stats types
+  export dimwit.stats.{Prob, LogProb}
+  export dimwit.stats.{Distribution, IndependentDistribution, MultivariateDistribution}

--- a/core/src/main/scala/dimwit/stats/Distributions.scala
+++ b/core/src/main/scala/dimwit/stats/Distributions.scala
@@ -7,8 +7,8 @@ import dimwit.jax.Jax.scipy_stats as jstats
 import dimwit.jax.Jax.PyDynamic
 import dimwit.tensor.TensorOps
 
-opaque type LogProb <: Float = Float
-opaque type Prob <: Float = Float
+opaque type LogProb = Float
+opaque type Prob = Float
 
 object LogProb:
 

--- a/core/src/main/scala/dimwit/stats/Distributions.scala
+++ b/core/src/main/scala/dimwit/stats/Distributions.scala
@@ -99,15 +99,3 @@ object IndependentDistribution:
           univariate.logProb(xi)
         }
         logprobs.unflatten(shape)
-
-/** Distribution over a single random variable.
-  * Note that most distributions are
-  * directly implemented as IndependentDistributions, for which
-  * Univariate is a special case with EventShape = EmptyTuple.
-  * so this is only used for special cases like Categorical.
-  */
-trait UnivariateDistribution[V] extends Distribution[EmptyTuple, V]
-
-/** Distribution over a vector of random variables.
-  */
-trait MultivariateDistribution[L: Label, V] extends Distribution[Tuple1[L], V]

--- a/core/src/main/scala/dimwit/stats/Distributions.scala
+++ b/core/src/main/scala/dimwit/stats/Distributions.scala
@@ -20,14 +20,19 @@ object LogProb:
 
     def exp: Tensor[T, Prob] = TensorOps.exp(t)
     def log: Tensor[T, Float] = TensorOps.log(t) // Lose LogProb if we log again
+    def asFloat: Tensor[T, Float] = t
 
 object Prob:
+
+  given IsFloating[Prob] = summon[IsFloating[Float]]
+
   def apply[T <: Tuple: Labels](t: Tensor[T, Float]): Tensor[T, Prob] = t
 
   extension [T <: Tuple: Labels](t: Tensor[T, Prob])
 
     def exp: Tensor[T, Float] = TensorOps.exp(t) // Lose Prob if we exp again
     def log: Tensor[T, LogProb] = TensorOps.log(t)
+    def asFloat: Tensor[T, Float] = t
 
 trait Distribution[EventShape <: Tuple: Labels, V]:
 
@@ -79,22 +84,30 @@ object IndependentDistribution:
   ): IndependentDistribution[EventShape, V] =
     new IndependentDistribution[EventShape, V]:
       override def sample(k: Random.Key): Tensor[EventShape, V] =
-        // sample using vmap for efficiency
 
         val flatSize = shape.dimensions.product
         trait Samples derives Label
-        val samples = k.splitvmap(Axis[Samples] -> flatSize) { key =>
+        val samples = k.splitvmap(Axis[Samples] -> flatSize): key =>
           univariate.sample(key)
-        }
-        samples.reshape(shape)
+
+        samples.unflatten(shape)
 
       override def elementWiseLogProb(x: Tensor[EventShape, V]): Tensor[EventShape, LogProb] =
-        trait Sample derives Label
-        val xflattened = x.reshape(Shape(Axis[Sample] -> x.shape.dimensions.product))
-        val logprobs = xflattened.vmap(Axis[Sample]) { xi =>
+        trait Samples derives Label
+        val flattened = x.flatten.relabelTo(Axis[Samples])
+        val logprobs = flattened.vmap(Axis[Samples]) { xi =>
           univariate.logProb(xi)
         }
-        logprobs.reshape(shape)
+        logprobs.unflatten(shape)
 
-type UnivariateDistribution[V] = Distribution[EmptyTuple, V]
-type MultivariateDistribution[L, V] = Distribution[Tuple1[L], V]
+/** Distribution over a single random variable.
+  * Note that most distributions are
+  * directly implemented as IndependentDistributions, for which
+  * Univariate is a special case with EventShape = EmptyTuple.
+  * so this is only used for special cases like Categorical.
+  */
+trait UnivariateDistribution[V] extends Distribution[EmptyTuple, V]
+
+/** Distribution over a vector of random variables.
+  */
+trait MultivariateDistribution[L: Label, V] extends Distribution[Tuple1[L], V]

--- a/core/src/main/scala/dimwit/stats/Distributions.scala
+++ b/core/src/main/scala/dimwit/stats/Distributions.scala
@@ -29,22 +29,72 @@ object Prob:
     def exp: Tensor[T, Float] = TensorOps.exp(t) // Lose Prob if we exp again
     def log: Tensor[T, LogProb] = TensorOps.log(t)
 
-/** Independent Distributions over all the given dimensions
+trait Distribution[EventShape <: Tuple: Labels, V]:
+
+  /** Sample from the distribution */
+  def sample(k: Random.Key): Tensor[EventShape, V]
+
+  /** Compute log probability (always returns scalar) */
+  def logProb(x: Tensor[EventShape, V]): Tensor0[LogProb]
+
+  /** Probability (exponentiated log probability) */
+  def prob(x: Tensor[EventShape, V]): Tensor0[Prob] =
+    logProb(x).exp
+
+/** Independent distribution - tensor of independent random variables.
+  *
+  * Represents a tensor of independent values, each drawn from the same distribution.
+  * This extends Distribution, so logProb returns a scalar (joint probability).
+  *
+  * - logProb returns scalar: sum of element-wise log probabilities
+  * - elementWiseLogProb returns tensor: individual log probabilities per element
+  * - Use vmap for batching: samples.vmap(Axis[Batch])(dist.logProb)
+  *
+  * @tparam EventShape Shape of the tensor of independent values
+  * @tparam V Value type
   */
-trait IndependentDistribution[T <: Tuple: Labels, V]:
+trait IndependentDistribution[EventShape <: Tuple: Labels, V: ExecutionType: IsNumber] extends Distribution[EventShape, V]:
 
-  def prob(x: Tensor[T, V]): Tensor[T, Prob] =
-    logProb(x).exp
+  /** Element-wise log probabilities (primitive operation) */
+  def elementWiseLogProb(x: Tensor[EventShape, V]): Tensor[EventShape, LogProb]
 
-  def logProb(x: Tensor[T, V]): Tensor[T, LogProb]
+  /** Joint log probability - sums element-wise log probs (final implementation) */
+  final override def logProb(x: Tensor[EventShape, V]): Tensor0[LogProb] =
+    elementWiseLogProb(x).sum
 
-  def sample(k: Random.Key): Tensor[T, V]
+  /** Element-wise probabilities */
+  def elementWiseProb(x: Tensor[EventShape, V]): Tensor[EventShape, Prob] =
+    elementWiseLogProb(x).exp
 
-trait MultivariateDistribution[T <: Tuple, V]:
+object IndependentDistribution:
 
-  def prob(x: Tensor[T, V]): Tensor0[Prob] =
-    logProb(x).exp
+  /** Create an Independent distribution from a univariate and a shape.
+    *
+    * Each element of the resulting tensor is an independent sample from
+    * the same univariate distribution.
+    */
+  def fromUnivariate[EventShape <: Tuple: Labels, V: ExecutionType: IsNumber](
+      shape: Shape[EventShape],
+      univariate: UnivariateDistribution[V]
+  ): IndependentDistribution[EventShape, V] =
+    new IndependentDistribution[EventShape, V]:
+      override def sample(k: Random.Key): Tensor[EventShape, V] =
+        // sample using vmap for efficiency
 
-  def logProb(x: Tensor[T, V]): Tensor0[LogProb]
+        val flatSize = shape.dimensions.product
+        trait Samples derives Label
+        val samples = k.splitvmap(Axis[Samples] -> flatSize) { key =>
+          univariate.sample(key)
+        }
+        samples.reshape(shape)
 
-  def sample(k: Random.Key): Tensor[T, V]
+      override def elementWiseLogProb(x: Tensor[EventShape, V]): Tensor[EventShape, LogProb] =
+        trait Sample derives Label
+        val xflattened = x.reshape(Shape(Axis[Sample] -> x.shape.dimensions.product))
+        val logprobs = xflattened.vmap(Axis[Sample]) { xi =>
+          univariate.logProb(xi)
+        }
+        logprobs.reshape(shape)
+
+type UnivariateDistribution[V] = Distribution[EmptyTuple, V]
+type MultivariateDistribution[L, V] = Distribution[Tuple1[L], V]

--- a/core/src/main/scala/dimwit/stats/IndependentDistributions.scala
+++ b/core/src/main/scala/dimwit/stats/IndependentDistributions.scala
@@ -53,7 +53,7 @@ object Uniform:
     new Uniform(low, high)
 
 /** Bernoulli distribution */
-class Bernoulli[T <: Tuple: Labels](val probs: Tensor[T, Float]) extends IndependentDistribution[T, Int]:
+class Bernoulli[T <: Tuple: Labels](val probs: Tensor[T, Prob]) extends IndependentDistribution[T, Int]:
 
   override def elementWiseLogProb(x: Tensor[T, Int]): Tensor[T, LogProb] =
     Tensor.fromPy(VType[LogProb])(jstats.bernoulli.logpmf(x.jaxValue, p = probs.jaxValue))
@@ -64,7 +64,7 @@ class Bernoulli[T <: Tuple: Labels](val probs: Tensor[T, Float]) extends Indepen
 object Bernoulli:
 
   /** Create a Bernoulli distribution from probability tensor */
-  def apply[T <: Tuple: Labels](probs: Tensor[T, Float]): Bernoulli[T] =
+  def apply[T <: Tuple: Labels](probs: Tensor[T, Prob]): Bernoulli[T] =
     new Bernoulli(probs)
 
 /** Cauchy distribution */
@@ -87,15 +87,18 @@ object Cauchy:
 class HalfNormal[T <: Tuple: Labels](val loc: Tensor[T, Float], val scale: Tensor[T, Float]) extends IndependentDistribution[T, Float]:
 
   override def elementWiseLogProb(x: Tensor[T, Float]): Tensor[T, LogProb] =
-    // Half-normal is a folded normal: logpdf = log(2) + norm.logpdf
-    Tensor.fromPy(VType[LogProb])(
+    // Half-normal logpdf = log(2) + norm.logpdf for x >= loc, -inf otherwise
+    val rawLogProb = Tensor.fromPy[T, LogProb](VType[LogProb])(
       Jax.jnp.log(2.0) + jstats.norm.logpdf(x.jaxValue, loc = loc.jaxValue, scale = scale.jaxValue)
     )
+    val valid = x >= loc
+    val negInf = LogProb(Tensor.like(x).fill(Float.NegativeInfinity))
+    where(valid, rawLogProb, negInf)
 
   override def sample(k: Random.Key): Tensor[T, Float] =
-    // Half-normal: sample from normal and take absolute value
+    // Half-normal: |N(0,1)| * scale + loc
     val normal = Tensor.fromPy[T, Float](VType[Float])(Jax.jrandom.normal(k.jaxKey, shape = loc.shape.dimensions.toPythonProxy))
-    (normal * scale + loc).abs
+    normal.abs * scale + loc
 
 object HalfNormal:
 
@@ -105,7 +108,7 @@ object HalfNormal:
     new HalfNormal(loc, scale)
 
 /** Student's t-distribution */
-class StudentT[T <: Tuple: Labels](val df: Int, val loc: Tensor[T, Float], val scale: Tensor[T, Float]) extends IndependentDistribution[T, Float]:
+class StudentT[T <: Tuple: Labels](val df: Float, val loc: Tensor[T, Float], val scale: Tensor[T, Float]) extends IndependentDistribution[T, Float]:
 
   override def elementWiseLogProb(x: Tensor[T, Float]): Tensor[T, LogProb] =
     Tensor.fromPy(VType[LogProb])(jstats.t.logpdf(x.jaxValue, df = df, loc = loc.jaxValue, scale = scale.jaxValue))
@@ -118,6 +121,6 @@ class StudentT[T <: Tuple: Labels](val df: Int, val loc: Tensor[T, Float], val s
 object StudentT:
 
   /** Create a Student's t-distribution from parameters */
-  def apply[T <: Tuple: Labels](df: Int, loc: Tensor[T, Float], scale: Tensor[T, Float]): StudentT[T] =
+  def apply[T <: Tuple: Labels](df: Float, loc: Tensor[T, Float], scale: Tensor[T, Float]): StudentT[T] =
     require(loc.shape.dimensions == scale.shape.dimensions, "loc, and scale must have the same dimensions")
     new StudentT(df, loc, scale)

--- a/core/src/main/scala/dimwit/stats/IndependentDistributions.scala
+++ b/core/src/main/scala/dimwit/stats/IndependentDistributions.scala
@@ -8,14 +8,10 @@ import me.shadaj.scalapy.py
 import me.shadaj.scalapy.py.SeqConverters
 import dimwit.random.Random
 
-class Normal[T <: Tuple: Labels](
-    val loc: Tensor[T, Float],
-    val scale: Tensor[T, Float]
-) extends IndependentDistribution[T, Float]:
+/** Normal (Gaussian) distribution */
+class Normal[T <: Tuple: Labels](val loc: Tensor[T, Float], val scale: Tensor[T, Float]) extends IndependentDistribution[T, Float]:
 
-  require(loc.shape.dimensions == scale.shape.dimensions, "loc and scale must have the same dimensions")
-
-  override def logProb(x: Tensor[T, Float]): Tensor[T, LogProb] =
+  override def elementWiseLogProb(x: Tensor[T, Float]): Tensor[T, LogProb] =
     Tensor.fromPy(VType[LogProb])(jstats.norm.logpdf(x.jaxValue, loc = loc.jaxValue, scale = scale.jaxValue))
 
   override def sample(key: Random.Key): Tensor[T, Float] =
@@ -24,19 +20,24 @@ class Normal[T <: Tuple: Labels](
 
 object Normal:
 
-  def standardSample(key: Random.Key): Tensor0[Float] = standardNormal(Shape.empty).sample(key)
-  def standardNormal[T <: Tuple: Labels](shape: Shape[T])(using executionType: ExecutionType[Float]) = new Normal(
-    loc = Tensor(shape).fill(0f),
-    scale = Tensor(shape).fill(1f)
-  )
+  /** Create a Normal distribution from location and scale tensors */
+  def apply[T <: Tuple: Labels](loc: Tensor[T, Float], scale: Tensor[T, Float]): Normal[T] =
+    require(loc.shape.dimensions == scale.shape.dimensions, "loc and scale must have the same dimensions")
+    new Normal(loc, scale)
 
-class Uniform[T <: Tuple: Labels](
-    val low: Tensor[T, Float],
-    val high: Tensor[T, Float]
-) extends IndependentDistribution[T, Float]:
-  require(low.shape.dimensions == high.shape.dimensions, "Low and high must have the same dimensions")
+  /** Sample from standard normal distribution N(0, 1) */
+  def standardSample(key: Random.Key): Tensor0[Float] = new Normal(Tensor0(0f), Tensor0(1f)).sample(key)
 
-  override def logProb(x: Tensor[T, Float]): Tensor[T, LogProb] =
+  def standardNormal[T <: Tuple: Labels](shape: Shape[T])(using executionType: ExecutionType[Float]): Normal[T] =
+    Normal(
+      loc = Tensor(shape).fill(0f),
+      scale = Tensor(shape).fill(1f)
+    )
+
+/** Uniform distribution */
+class Uniform[T <: Tuple: Labels](val low: Tensor[T, Float], val high: Tensor[T, Float]) extends IndependentDistribution[T, Float]:
+
+  override def elementWiseLogProb(x: Tensor[T, Float]): Tensor[T, LogProb] =
     Tensor.fromPy(VType[LogProb])(jstats.uniform.logpdf(x.jaxValue, loc = low.jaxValue, scale = (high - low).jaxValue))
 
   override def sample(key: Random.Key): Tensor[T, Float] =
@@ -44,36 +45,48 @@ class Uniform[T <: Tuple: Labels](
       Jax.jrandom.uniform(key.jaxKey, shape = low.shape.dimensions.toPythonProxy, minval = low.jaxValue, maxval = high.jaxValue)
     )
 
-class Bernoulli[T <: Tuple: Labels](
-    val probs: Tensor[T, Float]
-) extends IndependentDistribution[T, Int]:
+object Uniform:
 
-  override def logProb(x: Tensor[T, Int]): Tensor[T, LogProb] =
+  /** Create a Uniform distribution from low and high tensors */
+  def apply[T <: Tuple: Labels](low: Tensor[T, Float], high: Tensor[T, Float]): Uniform[T] =
+    require(low.shape.dimensions == high.shape.dimensions, "Low and high must have the same dimensions")
+    new Uniform(low, high)
+
+/** Bernoulli distribution */
+class Bernoulli[T <: Tuple: Labels](val probs: Tensor[T, Float]) extends IndependentDistribution[T, Int]:
+
+  override def elementWiseLogProb(x: Tensor[T, Int]): Tensor[T, LogProb] =
     Tensor.fromPy(VType[LogProb])(jstats.bernoulli.logpmf(x.jaxValue, p = probs.jaxValue))
 
   override def sample(key: Random.Key): Tensor[T, Int] =
     Tensor.fromPy(VType[Int])(Jax.jrandom.bernoulli(key.jaxKey, p = probs.jaxValue))
 
-class Cauchy[T <: Tuple: Labels](
-    val loc: Tensor[T, Float],
-    val scale: Tensor[T, Float]
-) extends IndependentDistribution[T, Float]:
-  require(loc.shape.dimensions == scale.shape.dimensions, "Location and scale must have the same dimensions")
+object Bernoulli:
 
-  override def logProb(x: Tensor[T, Float]): Tensor[T, LogProb] =
+  /** Create a Bernoulli distribution from probability tensor */
+  def apply[T <: Tuple: Labels](probs: Tensor[T, Float]): Bernoulli[T] =
+    new Bernoulli(probs)
+
+/** Cauchy distribution */
+class Cauchy[T <: Tuple: Labels](val loc: Tensor[T, Float], val scale: Tensor[T, Float]) extends IndependentDistribution[T, Float]:
+
+  override def elementWiseLogProb(x: Tensor[T, Float]): Tensor[T, LogProb] =
     Tensor.fromPy(VType[LogProb])(jstats.cauchy.logpdf(x.jaxValue, loc = loc.jaxValue, scale = scale.jaxValue))
 
   override def sample(k: Random.Key): Tensor[T, Float] =
     Tensor.fromPy(VType[Float])(Jax.jrandom.cauchy(k.jaxKey, shape = loc.shape.dimensions.toPythonProxy)) * scale + loc
 
-class HalfNormal[T <: Tuple: Labels](
-    val loc: Tensor[T, Float],
-    val scale: Tensor[T, Float]
-) extends IndependentDistribution[T, Float]:
+object Cauchy:
 
-  require(loc.shape.dimensions == scale.shape.dimensions, "Mean and scale must have the same dimensions")
+  /** Create a Cauchy distribution from location and scale tensors */
+  def apply[T <: Tuple: Labels](loc: Tensor[T, Float], scale: Tensor[T, Float]): Cauchy[T] =
+    require(loc.shape.dimensions == scale.shape.dimensions, "Location and scale must have the same dimensions")
+    new Cauchy(loc, scale)
 
-  override def logProb(x: Tensor[T, Float]): Tensor[T, LogProb] =
+/** Half-normal distribution */
+class HalfNormal[T <: Tuple: Labels](val loc: Tensor[T, Float], val scale: Tensor[T, Float]) extends IndependentDistribution[T, Float]:
+
+  override def elementWiseLogProb(x: Tensor[T, Float]): Tensor[T, LogProb] =
     // Half-normal is a folded normal: logpdf = log(2) + norm.logpdf
     Tensor.fromPy(VType[LogProb])(
       Jax.jnp.log(2.0) + jstats.norm.logpdf(x.jaxValue, loc = loc.jaxValue, scale = scale.jaxValue)
@@ -84,17 +97,27 @@ class HalfNormal[T <: Tuple: Labels](
     val normal = Tensor.fromPy[T, Float](VType[Float])(Jax.jrandom.normal(k.jaxKey, shape = loc.shape.dimensions.toPythonProxy))
     (normal * scale + loc).abs
 
-class StudentT[T <: Tuple: Labels](
-    val df: Int,
-    val loc: Tensor[T, Float],
-    val scale: Tensor[T, Float]
-) extends IndependentDistribution[T, Float]:
-  require(loc.shape.dimensions == scale.shape.dimensions, "loc, and scale must have the same dimensions")
+object HalfNormal:
 
-  override def logProb(x: Tensor[T, Float]): Tensor[T, LogProb] =
+  /** Create a half-normal distribution from location and scale tensors */
+  def apply[T <: Tuple: Labels](loc: Tensor[T, Float], scale: Tensor[T, Float]): HalfNormal[T] =
+    require(loc.shape.dimensions == scale.shape.dimensions, "Mean and scale must have the same dimensions")
+    new HalfNormal(loc, scale)
+
+/** Student's t-distribution */
+class StudentT[T <: Tuple: Labels](val df: Int, val loc: Tensor[T, Float], val scale: Tensor[T, Float]) extends IndependentDistribution[T, Float]:
+
+  override def elementWiseLogProb(x: Tensor[T, Float]): Tensor[T, LogProb] =
     Tensor.fromPy(VType[LogProb])(jstats.t.logpdf(x.jaxValue, df = df, loc = loc.jaxValue, scale = scale.jaxValue))
 
   override def sample(k: Random.Key): Tensor[T, Float] =
     Tensor.fromPy(VType[Float])(
       Jax.jrandom.t(k.jaxKey, df = df, shape = loc.shape.dimensions.toPythonProxy)
     ) * scale + loc
+
+object StudentT:
+
+  /** Create a Student's t-distribution from parameters */
+  def apply[T <: Tuple: Labels](df: Int, loc: Tensor[T, Float], scale: Tensor[T, Float]): StudentT[T] =
+    require(loc.shape.dimensions == scale.shape.dimensions, "loc, and scale must have the same dimensions")
+    new StudentT(df, loc, scale)

--- a/core/src/main/scala/dimwit/stats/IndependentDistributions.scala
+++ b/core/src/main/scala/dimwit/stats/IndependentDistributions.scala
@@ -67,6 +67,27 @@ object Bernoulli:
   def apply[T <: Tuple: Labels](probs: Tensor[T, Prob]): Bernoulli[T] =
     new Bernoulli(probs)
 
+/** Binomial distribution - number of successes in n independent Bernoulli trials */
+class Binomial[T <: Tuple: Labels](val n: Int, val probs: Tensor[T, Prob]) extends IndependentDistribution[T, Int]:
+
+  override def elementWiseLogProb(x: Tensor[T, Int]): Tensor[T, LogProb] =
+    Tensor.fromPy(VType[LogProb])(jstats.binom.logpmf(x.jaxValue, n = n, p = probs.jaxValue))
+
+  override def sample(key: Random.Key): Tensor[T, Int] =
+    // Sum n independent Bernoulli(p) trials
+    trait Trials derives Label
+    val trialSamples = key.splitvmap(Axis[Trials] -> n) { k =>
+      Tensor.fromPy(VType[Int])(Jax.jrandom.bernoulli(k.jaxKey, p = probs.jaxValue))
+    }
+    trialSamples.sum(Axis[Trials])
+
+object Binomial:
+
+  /** Create a Binomial distribution from number of trials and probability tensor */
+  def apply[T <: Tuple: Labels](n: Int, probs: Tensor[T, Prob]): Binomial[T] =
+    require(n > 0, "Number of trials must be positive")
+    new Binomial(n, probs)
+
 /** Cauchy distribution */
 class Cauchy[T <: Tuple: Labels](val loc: Tensor[T, Float], val scale: Tensor[T, Float]) extends IndependentDistribution[T, Float]:
 

--- a/core/src/main/scala/dimwit/stats/MultivariateDistributions.scala
+++ b/core/src/main/scala/dimwit/stats/MultivariateDistributions.scala
@@ -6,6 +6,10 @@ import dimwit.jax.Jax
 import dimwit.jax.Jax.scipy_stats as jstats
 import dimwit.jax.Jax.PyDynamic
 
+/** Distribution over a vector of random variables.
+  */
+trait MultivariateDistribution[L: Label, V] extends Distribution[Tuple1[L], V]
+
 class MVNormal[L: Label](
     val mean: Tensor1[L, Float],
     val covariance: Tensor2[L, Prime[L], Float]
@@ -55,17 +59,3 @@ class Multinomial[L: Label](
     Tensor.fromPy(VType[Int])(
       Jax.jnp.bincount(draws.jaxValue, length = probs.shape.dimensions(0))
     )
-
-class Categorical[L: Label](val probs: Tensor1[L, Prob]) extends UnivariateDistribution[Int]:
-
-  private val logProbs: Tensor1[L, LogProb] = probs.log
-
-  override def logProb(x: Tensor0[Int]): Tensor0[LogProb] =
-    Tensor.fromPy(VType[LogProb])(logProbs.jaxValue.__getitem__(x.jaxValue))
-
-  override def sample(key: Random.Key): Tensor0[Int] =
-    Tensor.fromPy(VType[Int])(Jax.jrandom.categorical(key.jaxKey, logProbs.jaxValue))
-
-object Categorical:
-  def apply[L: Label](probs: Tensor1[L, Prob]): Categorical[L] = new Categorical(probs)
-  def fromFloat[L: Label](probs: Tensor1[L, Float]): Categorical[L] = new Categorical(Prob(probs))

--- a/core/src/main/scala/dimwit/stats/MultivariateDistributions.scala
+++ b/core/src/main/scala/dimwit/stats/MultivariateDistributions.scala
@@ -5,13 +5,11 @@ import dimwit.random.Random
 import dimwit.jax.Jax
 import dimwit.jax.Jax.scipy_stats as jstats
 import dimwit.jax.Jax.PyDynamic
-import me.shadaj.scalapy.py
-import me.shadaj.scalapy.py.SeqConverters
 
 class MVNormal[L: Label](
     val mean: Tensor1[L, Float],
     val covariance: Tensor2[L, Prime[L], Float]
-) extends Distribution[Tuple1[L], Float]:
+) extends MultivariateDistribution[L, Float]:
 
   override def logProb(x: Tensor1[L, Float]): Tensor0[LogProb] =
     Tensor.fromPy(VType[LogProb])(jstats.multivariate_normal.logpdf(x.jaxValue, mean = mean.jaxValue, cov = covariance.jaxValue))
@@ -27,7 +25,7 @@ class MVNormal[L: Label](
 
 class Dirichlet[L: Label](
     val concentration: Tensor1[L, Float]
-) extends Distribution[Tuple1[L], Float]:
+) extends MultivariateDistribution[L, Float]:
 
   override def logProb(x: Tensor1[L, Float]): Tensor0[LogProb] =
     Tensor.fromPy(VType[LogProb])(jstats.dirichlet.logpdf(x.jaxValue, alpha = concentration.jaxValue))
@@ -43,33 +41,31 @@ class Dirichlet[L: Label](
 class Multinomial[L: Label](
     val n: Int,
     val probs: Tensor1[L, Prob]
-) extends Distribution[Tuple1[L], Int]:
+) extends MultivariateDistribution[L, Int]:
 
-  private lazy val logProbs: Tensor1[L, LogProb] = probs.log
+  private val categorical: Categorical[L] = Categorical(probs)
 
   override def logProb(x: Tensor1[L, Int]): Tensor0[LogProb] =
     Tensor.fromPy(VType[LogProb])(jstats.multinomial.logpmf(x.jaxValue, n = n, p = probs.jaxValue))
 
   override def sample(key: Random.Key): Tensor1[L, Int] =
-    // Sample from categorical n times using vmap, then bincount
-    val splitKeys = Jax.jrandom.split(key.jaxKey, n)
-    // Use vmap to apply categorical to all keys
-    val vmapCategorical = Jax.jax.vmap(
-      py.Dynamic.global.eval("lambda k, lp: __import__('jax').random.categorical(k, lp)"),
-      in_axes = (0, py.None)
-    )
-    val samples = vmapCategorical(splitKeys, logProbs.jaxValue)
+    // Sample from categorical n times using splitvmap, then bincount
+    trait Draws derives Label
+    val draws = key.splitvmap(Axis[Draws] -> n)(k => categorical.sample(k))
     Tensor.fromPy(VType[Int])(
-      Jax.jnp.bincount(samples, length = probs.shape.dimensions(0))
+      Jax.jnp.bincount(draws.jaxValue, length = probs.shape.dimensions(0))
     )
 
-class Categorical[L: Label](val probs: Tensor1[L, Float]) extends Distribution[EmptyTuple, Int]:
+class Categorical[L: Label](val probs: Tensor1[L, Prob]) extends UnivariateDistribution[Int]:
 
-  private val numCategories = probs.shape.dimensions(0)
-  private val logProbs = probs.log
+  private val logProbs: Tensor1[L, LogProb] = probs.log
 
   override def logProb(x: Tensor0[Int]): Tensor0[LogProb] =
     Tensor.fromPy(VType[LogProb])(logProbs.jaxValue.__getitem__(x.jaxValue))
 
   override def sample(key: Random.Key): Tensor0[Int] =
     Tensor.fromPy(VType[Int])(Jax.jrandom.categorical(key.jaxKey, logProbs.jaxValue))
+
+object Categorical:
+  def apply[L: Label](probs: Tensor1[L, Prob]): Categorical[L] = new Categorical(probs)
+  def fromFloat[L: Label](probs: Tensor1[L, Float]): Categorical[L] = new Categorical(Prob(probs))

--- a/core/src/main/scala/dimwit/stats/MultivariateDistributions.scala
+++ b/core/src/main/scala/dimwit/stats/MultivariateDistributions.scala
@@ -11,12 +11,12 @@ import me.shadaj.scalapy.py.SeqConverters
 class MVNormal[L: Label](
     val mean: Tensor1[L, Float],
     val covariance: Tensor2[L, Prime[L], Float]
-) extends MultivariateDistribution[Tuple1[L], Float]:
+) extends Distribution[Tuple1[L], Float]:
 
   override def logProb(x: Tensor1[L, Float]): Tensor0[LogProb] =
     Tensor.fromPy(VType[LogProb])(jstats.multivariate_normal.logpdf(x.jaxValue, mean = mean.jaxValue, cov = covariance.jaxValue))
 
-  override def sample(k: Random.Key): Tensor[Tuple1[L], Float] =
+  override def sample(k: Random.Key): Tensor1[L, Float] =
     Tensor.fromPy(VType[Float])(
       Jax.jrandom.multivariate_normal(
         k.jaxKey,
@@ -27,7 +27,7 @@ class MVNormal[L: Label](
 
 class Dirichlet[L: Label](
     val concentration: Tensor1[L, Float]
-) extends MultivariateDistribution[Tuple1[L], Float]:
+) extends Distribution[Tuple1[L], Float]:
 
   override def logProb(x: Tensor1[L, Float]): Tensor0[LogProb] =
     Tensor.fromPy(VType[LogProb])(jstats.dirichlet.logpdf(x.jaxValue, alpha = concentration.jaxValue))
@@ -43,7 +43,7 @@ class Dirichlet[L: Label](
 class Multinomial[L: Label](
     val n: Int,
     val probs: Tensor1[L, Prob]
-) extends MultivariateDistribution[Tuple1[L], Int]:
+) extends Distribution[Tuple1[L], Int]:
 
   private lazy val logProbs: Tensor1[L, LogProb] = probs.log
 
@@ -63,7 +63,7 @@ class Multinomial[L: Label](
       Jax.jnp.bincount(samples, length = probs.shape.dimensions(0))
     )
 
-class Categorical[L: Label](val probs: Tensor1[L, Float]) extends MultivariateDistribution[EmptyTuple, Int]:
+class Categorical[L: Label](val probs: Tensor1[L, Float]) extends Distribution[EmptyTuple, Int]:
 
   private val numCategories = probs.shape.dimensions(0)
   private val logProbs = probs.log

--- a/core/src/main/scala/dimwit/stats/UnivariateDistributions.scala
+++ b/core/src/main/scala/dimwit/stats/UnivariateDistributions.scala
@@ -1,0 +1,26 @@
+package dimwit.stats
+
+import dimwit.*
+import dimwit.jax.Jax
+
+/** Distribution over a single random variable.
+  * Note that most distributions are
+  * directly implemented as IndependentDistributions, for which
+  * Univariate is a special case with EventShape = EmptyTuple.
+  * so this is only used for special cases like Categorical.
+  */
+trait UnivariateDistribution[V] extends Distribution[EmptyTuple, V]
+
+class Categorical[L: Label](val probs: Tensor1[L, Prob]) extends UnivariateDistribution[Int]:
+
+  private val logProbs: Tensor1[L, LogProb] = probs.log
+
+  override def logProb(x: Tensor0[Int]): Tensor0[LogProb] =
+    Tensor.fromPy(VType[LogProb])(logProbs.jaxValue.__getitem__(x.jaxValue))
+
+  override def sample(key: Random.Key): Tensor0[Int] =
+    Tensor.fromPy(VType[Int])(Jax.jrandom.categorical(key.jaxKey, logProbs.jaxValue))
+
+object Categorical:
+  def apply[L: Label](probs: Tensor1[L, Prob]): Categorical[L] = new Categorical(probs)
+  def fromFloat[L: Label](probs: Tensor1[L, Float]): Categorical[L] = new Categorical(Prob(probs))

--- a/core/src/main/scala/dimwit/tensor/Tensor.scala
+++ b/core/src/main/scala/dimwit/tensor/Tensor.scala
@@ -13,7 +13,6 @@ import dimwit.stats.{Normal, Uniform}
 import me.shadaj.scalapy.readwrite.Writer
 import scala.reflect.ClassTag
 import scala.annotation.unchecked.uncheckedVariance
-import dimwit.stats.IndependentDistribution
 import dimwit.Prime
 
 enum Device(val platform: String):

--- a/core/src/test/scala/dimwit/stats/DistributionSuite.scala
+++ b/core/src/test/scala/dimwit/stats/DistributionSuite.scala
@@ -70,7 +70,7 @@ class DistributionSuite extends AnyFunSpec with Matchers:
       val probs = Tensor(Shape(Axis[A] -> 3)).fromArray(Array(0.3f, 0.5f, 0.8f))
       val x = Tensor(Shape(Axis[A] -> 3)).fromArray(Array(0, 1, 1))
 
-      val dist = Bernoulli(probs)
+      val dist = Bernoulli(Prob(probs))
       val scalaLogProbs = dist.elementWiseLogProb(x)
       val jaxLogProbs = Tensor.fromPy[Tuple1[A], Float](VType[Float])(
         jstats.bernoulli.logpmf(x.jaxValue, p = probs.jaxValue)
@@ -79,12 +79,12 @@ class DistributionSuite extends AnyFunSpec with Matchers:
 
     it("sample means approximates probabilities"):
       val bernoulli = Bernoulli(
-        Tensor(Shape(Axis[A] -> 2)).fromArray(Array(0.3f, 0.7f))
+        Prob(Tensor(Shape(Axis[A] -> 2)).fromArray(Array(0.3f, 0.7f)))
       )
       val key = Random.Key(42)
       val samples = key.splitvmap(Axis[Samples] -> 1000)(k => bernoulli.sample(k))
       val sampleMeans = samples.asFloat.mean(Axis[Samples])
-      val expectedMeans = bernoulli.probs
+      val expectedMeans = bernoulli.probs.asFloat
       sampleMeans should approxEqual(expectedMeans, 0.1f)
 
   describe("Cauchy"):
@@ -140,7 +140,7 @@ class DistributionSuite extends AnyFunSpec with Matchers:
 
   describe("StudentT"):
     it("logProbs matches JAX"):
-      val df = 5
+      val df = 5.0f
       val loc = Tensor(Shape(Axis[A] -> 3)).fromArray(Array(0.0f, 1.0f, -0.5f))
       val scale = Tensor(Shape(Axis[A] -> 3)).fromArray(Array(1.0f, 0.5f, 2.0f))
       val x = Tensor(Shape(Axis[A] -> 3)).fromArray(Array(0.5f, 1.5f, -1.0f))
@@ -154,7 +154,7 @@ class DistributionSuite extends AnyFunSpec with Matchers:
 
     it("sample means approximates location"):
       val studentT = StudentT(
-        df = 5,
+        df = 5.0f,
         loc = Tensor(Shape(Axis[A] -> 2)).fromArray(Array(0.0f, 2.0f)),
         scale = Tensor(Shape(Axis[A] -> 2)).fromArray(Array(1.0f, 0.5f))
       )
@@ -246,7 +246,7 @@ class DistributionSuite extends AnyFunSpec with Matchers:
 
   describe("Categorical"):
     it("logProb matches expected value"):
-      val probs = Tensor(Shape(Axis[A] -> 4)).fromArray(Array(0.1f, 0.2f, 0.3f, 0.4f))
+      val probs = Prob(Tensor(Shape(Axis[A] -> 4)).fromArray(Array(0.1f, 0.2f, 0.3f, 0.4f)))
       val x = Tensor0(2)
 
       val dist = Categorical(probs)
@@ -255,7 +255,7 @@ class DistributionSuite extends AnyFunSpec with Matchers:
       scalaLogProb.asFloat should approxEqual(expectedLogProb)
 
     it("sample distribution matches probabilities"):
-      val probs = Tensor(Shape(Axis[A] -> 4)).fromArray(Array(0.1f, 0.2f, 0.3f, 0.4f))
+      val probs = Prob(Tensor(Shape(Axis[A] -> 4)).fromArray(Array(0.1f, 0.2f, 0.3f, 0.4f)))
       val categorical = Categorical(probs)
       val key = Random.Key(42)
       val numSamples = 10000
@@ -264,4 +264,4 @@ class DistributionSuite extends AnyFunSpec with Matchers:
         Jax.jnp.bincount(samples.jaxValue, minlength = 4).astype(Jax.jnp.float32)
       )
       val frequencies = counts *! (1.0f / numSamples.toFloat)
-      frequencies should approxEqual(probs, 0.02f)
+      frequencies should approxEqual(probs.asFloat, 0.02f)

--- a/core/src/test/scala/dimwit/stats/DistributionSuite.scala
+++ b/core/src/test/scala/dimwit/stats/DistributionSuite.scala
@@ -87,6 +87,52 @@ class DistributionSuite extends AnyFunSpec with Matchers:
       val expectedMeans = bernoulli.probs.asFloat
       sampleMeans should approxEqual(expectedMeans, 0.1f)
 
+  describe("Binomial"):
+    it("logProbs matches JAX"):
+      val n = 10
+      val probs = Tensor(Shape(Axis[A] -> 3)).fromArray(Array(0.3f, 0.5f, 0.8f))
+      val x = Tensor(Shape(Axis[A] -> 3)).fromArray(Array(3, 5, 8))
+
+      val dist = Binomial(n, Prob(probs))
+      val scalaLogProbs = dist.elementWiseLogProb(x)
+      val jaxLogProbs = Tensor.fromPy[Tuple1[A], Float](VType[Float])(
+        jstats.binom.logpmf(x.jaxValue, n = n, p = probs.jaxValue)
+      )
+      scalaLogProbs.asFloat should approxEqual(jaxLogProbs)
+
+    it("sample means approximates n*p"):
+      val n = 20
+      val binomial = Binomial(
+        n,
+        Prob(Tensor(Shape(Axis[A] -> 2)).fromArray(Array(0.3f, 0.7f)))
+      )
+      val key = Random.Key(42)
+      val samples = key.splitvmap(Axis[Samples] -> 10000)(k => binomial.sample(k))
+      val sampleMeans = samples.asFloat.mean(Axis[Samples])
+      val expectedMeans = binomial.probs.asFloat *! n.toFloat
+      sampleMeans should approxEqual(expectedMeans, 0.5f)
+
+    it("reduces to Bernoulli when n=1"):
+      val n = 1
+      val probs = Tensor(Shape(Axis[A] -> 3)).fromArray(Array(0.2f, 0.5f, 0.9f))
+
+      val binomial = Binomial(n, Prob(probs))
+      val key = Random.Key(123)
+      val samples = key.splitvmap(Axis[Samples] -> 5000)(k => binomial.sample(k))
+      val sampleMeans = samples.asFloat.mean(Axis[Samples])
+      sampleMeans should approxEqual(probs, 0.1f)
+
+    it("handles edge cases p=0 and p=1"):
+      val n = 5
+      val probsEdge = Tensor(Shape(Axis[A] -> 2)).fromArray(Array(0.0f, 1.0f))
+
+      val binomial = Binomial(n, Prob(probsEdge))
+      val key = Random.Key(456)
+      val samples = key.splitvmap(Axis[Samples] -> 100)(k => binomial.sample(k))
+      val sampleMeans = samples.asFloat.mean(Axis[Samples])
+      val expectedMeans = Tensor(Shape(Axis[A] -> 2)).fromArray(Array(0.0f, n.toFloat))
+      sampleMeans should approxEqual(expectedMeans, 0.1f)
+
   describe("Cauchy"):
     it("logProbs matches JAX"):
       val loc = Tensor(Shape(Axis[A] -> 3)).fromArray(Array(0.0f, 1.0f, -0.5f))

--- a/core/src/test/scala/dimwit/stats/DistributionSuite.scala
+++ b/core/src/test/scala/dimwit/stats/DistributionSuite.scala
@@ -24,7 +24,7 @@ class DistributionSuite extends AnyFunSpec with Matchers:
       val x = Tensor(Shape(Axis[A] -> 3)).fromArray(Array(0.5f, 1.5f, -1.0f))
 
       val dist = Normal(loc, scale)
-      val scalaLogProbs = dist.logProb(x)
+      val scalaLogProbs = dist.elementWiseLogProb(x)
       val jaxLogProbs = Tensor.fromPy[Tuple1[A], Float](VType[Float])(
         jstats.norm.logpdf(x.jaxValue, loc = loc.jaxValue, scale = scale.jaxValue)
       )
@@ -48,7 +48,7 @@ class DistributionSuite extends AnyFunSpec with Matchers:
       val x = Tensor(Shape(Axis[A] -> 3)).fromArray(Array(0.5f, 0.0f, 3.0f))
 
       val dist = Uniform(low, high)
-      val scalaLogProbs = dist.logProb(x)
+      val scalaLogProbs = dist.elementWiseLogProb(x)
       val jaxLogProbs = Tensor.fromPy[Tuple1[A], Float](VType[Float])(
         jstats.uniform.logpdf(x.jaxValue, loc = low.jaxValue, scale = (high - low).jaxValue)
       )
@@ -71,7 +71,7 @@ class DistributionSuite extends AnyFunSpec with Matchers:
       val x = Tensor(Shape(Axis[A] -> 3)).fromArray(Array(0, 1, 1))
 
       val dist = Bernoulli(probs)
-      val scalaLogProbs = dist.logProb(x)
+      val scalaLogProbs = dist.elementWiseLogProb(x)
       val jaxLogProbs = Tensor.fromPy[Tuple1[A], Float](VType[Float])(
         jstats.bernoulli.logpmf(x.jaxValue, p = probs.jaxValue)
       )
@@ -94,7 +94,7 @@ class DistributionSuite extends AnyFunSpec with Matchers:
       val x = Tensor(Shape(Axis[A] -> 3)).fromArray(Array(0.5f, 1.5f, -1.0f))
 
       val dist = Cauchy(loc, scale)
-      val scalaLogProbs = dist.logProb(x)
+      val scalaLogProbs = dist.elementWiseLogProb(x)
       val jaxLogProbs = Tensor.fromPy[Tuple1[A], Float](VType[Float])(
         jstats.cauchy.logpdf(x.jaxValue, loc = loc.jaxValue, scale = scale.jaxValue)
       )
@@ -118,7 +118,7 @@ class DistributionSuite extends AnyFunSpec with Matchers:
       val x = Tensor(Shape(Axis[A] -> 3)).fromArray(Array(0.5f, 1.0f, 0.8f))
 
       val dist = HalfNormal(loc, scale)
-      val scalaLogProbs = dist.logProb(x)
+      val scalaLogProbs = dist.elementWiseLogProb(x)
       // Compute expected manually: log(2) + norm.logpdf for x >= loc
       val expectedLogProbs = Tensor.fromPy[Tuple1[A], Float](VType[Float])(
         jstats.norm.logpdf(x.jaxValue, loc = loc.jaxValue, scale = scale.jaxValue)
@@ -146,7 +146,7 @@ class DistributionSuite extends AnyFunSpec with Matchers:
       val x = Tensor(Shape(Axis[A] -> 3)).fromArray(Array(0.5f, 1.5f, -1.0f))
 
       val dist = StudentT(df, loc, scale)
-      val scalaLogProbs = dist.logProb(x)
+      val scalaLogProbs = dist.elementWiseLogProb(x)
       val jaxLogProbs = Tensor.fromPy[Tuple1[A], Float](VType[Float])(
         jstats.t.logpdf(x.jaxValue, df = df, loc = loc.jaxValue, scale = scale.jaxValue)
       )


### PR DESCRIPTION
This PR refactors the distribution hierarchy. In particular it adds a common trait that all distributions share. 
This requires IndependenDistributions to sum the logProbs to satisfy the common interface. To enable other operations that summing probabilities, an method `lementwiseLogProbs  is added.  

This PR also makes several smaller fixes, improving type safety and handling of corner cases. 

Finally, it also exposes Random and some more stats operations on package level. 

Note, this PR builds on the currently unmerged PR #64 . Once this is merged it might become much easier to review. 