### PR TITLE
Tensor distribution parameters

### DIFF
--- a/core/src/main/scala/dimwit/stats/MultivariateDistributions.scala
+++ b/core/src/main/scala/dimwit/stats/MultivariateDistributions.scala
@@ -43,19 +43,19 @@ class Dirichlet[L: Label](
     )
 
 class Multinomial[L: Label](
-    val n: Int,
+    val n: Tensor0[Int],
     val probs: Tensor1[L, Prob]
 ) extends MultivariateDistribution[L, Int]:
 
   private val categorical: Categorical[L] = Categorical(probs)
 
   override def logProb(x: Tensor1[L, Int]): Tensor0[LogProb] =
-    Tensor.fromPy(VType[LogProb])(jstats.multinomial.logpmf(x.jaxValue, n = n, p = probs.jaxValue))
+    Tensor.fromPy(VType[LogProb])(jstats.multinomial.logpmf(x.jaxValue, n = n.jaxValue, p = probs.jaxValue))
 
   override def sample(key: Random.Key): Tensor1[L, Int] =
     // Sample from categorical n times using splitvmap, then bincount
     trait Draws derives Label
-    val draws = key.splitvmap(Axis[Draws] -> n)(k => categorical.sample(k))
+    val draws = key.splitvmap(Axis[Draws] -> n.item)(k => categorical.sample(k))
     Tensor.fromPy(VType[Int])(
       Jax.jnp.bincount(draws.jaxValue, length = probs.shape.dimensions(0))
     )

--- a/core/src/main/scala/dimwit/stats/UnivariateDistributions.scala
+++ b/core/src/main/scala/dimwit/stats/UnivariateDistributions.scala
@@ -9,7 +9,7 @@ import dimwit.jax.Jax
   * Univariate is a special case with EventShape = EmptyTuple.
   * so this is only used for special cases like Categorical.
   */
-trait UnivariateDistribution[V] extends Distribution[EmptyTuple, V]
+type UnivariateDistribution[V] = Distribution[EmptyTuple, V]
 
 class Categorical[L: Label](val probs: Tensor1[L, Prob]) extends UnivariateDistribution[Int]:
 


### PR DESCRIPTION
Some distributions, such as the Binomial or Student's-t distribution had parameters that were raw ints. If we want to optimize for these parameters, they would need to be tensors. This is consistent with most of the other distributions (as e.g. normal) whose parameters are already tensors. 

This PR also adds a commit that makes Univariate Distribution a type alias instead of a trait, which makes it possible to treat any independent distribution with shape Tensor0 as a univariate distribution.