### PR TITLE
add fromPython/toJax wrappers to PyBridge

### DIFF
--- a/core/src/main/resources/python/jax_helper.py
+++ b/core/src/main/resources/python/jax_helper.py
@@ -8,18 +8,25 @@ import builtins
 builtins.jax = jax
 builtins.jnp = jnp
 
+def wrap(jax_transform, f, kwargs=None):
+    """
+    Generic wrapper that shields a ScalaPy function from JAX introspection,
+    then applies the given JAX transform.
+
+    Usage:
+        wrap(jax.grad, f)
+        wrap(jax.vmap, f, kwargs={"in_axes": 0})
+        wrap(jax.jit, f, kwargs={"donate_argnums": (0,)})
+        wrap(jax.jacfwd, f)
+    """
+    def python_wrapper(*a, **kw):
+        return f(*a, **kw)
+    if kwargs:
+        return jax_transform(python_wrapper, **kwargs)
+    return jax_transform(python_wrapper)
+
 def vmap(f, dims):
-    """
-    Applies a function `f` to a tensor using JAX's vmap functionality.
-    
-    It is wrapped in a Python function to ensure that the function, as otherwise
-    jax will crash upon inspection.
-    """
-                
-    def python_wrapper(x):
-        return f(x)
-            
-    return jax.vmap(python_wrapper, in_axes=dims)
+    return wrap(jax.vmap, f, kwargs={"in_axes": dims})
            
 def zipvmap(f, dims):
     def python_wrapper(*args):
@@ -46,118 +53,28 @@ def apply_over_axes(f, axis):
     return jnp.apply_over_axes(python_wrapper, axis)
 
 def vmap2(f, dims):
-    """
-    Applies a function `f` to two tensors using JAX's vmap functionality.
-    
-    Args:
-        f: Function that takes two arguments (x, y)
-        dims: Either an integer (same axis for both inputs) or tuple (axis1, axis2)
-    
-    It is wrapped in a Python function to ensure that the function, as otherwise
-    jax will crash upon inspection.
-    """
-                
-    # Wrap the ScalaPy function in a pure Python wrapper
-    def python_wrapper(x, y):
-        return f(x, y)
-    
-    # Handle dims parameter - can be int or tuple
-    if isinstance(dims, int):
-        # Same axis for both inputs
-        in_axes = (dims, dims)
-    else:
-        # Different axes for each input
-        in_axes = dims
-            
-    # Create vmap with the wrapper
-    return jax.vmap(python_wrapper, in_axes=in_axes)
+    in_axes = (dims, dims) if isinstance(dims, int) else dims
+    return wrap(jax.vmap, f, kwargs={"in_axes": in_axes})
 
 
 
 def grad(f):
-    """
-    Computes the gradient of a function `f` with respect to its arguments.
-    
-    This is a simple wrapper around JAX's grad function.
-    Only works for scalar-output functions.
-    """
-    from jax import grad as jax_grad
-    def python_wrapper(*args):
-        # Remove debug print that might cause issues
-        return f(*args)
-    
-    return jax_grad(python_wrapper)
+    return wrap(jax.grad, f)
 
 def value_and_grad(f):
-    """
-    Computes both the value and gradient of a function `f` with respect to its arguments.
-    
-    This is more efficient than computing value and gradient separately.
-    Only works for scalar-output functions.
-    """
-    from jax import value_and_grad as jax_value_and_grad
-    def python_wrapper(*args):
-        return f(*args)
-    
-    return jax_value_and_grad(python_wrapper)
+    return wrap(jax.value_and_grad, f)
 
 def jacfwd(f):
-    """
-    Computes the Jacobian of a function `f` using forward-mode differentiation.
-    
-    Works for vector-output functions. Efficient when output dimension > input dimension.
-    """
-    from jax import jacfwd as jax_jacfwd
-    def python_wrapper(x):
-        return f(x)
-    
-    return jax_jacfwd(python_wrapper)
+    return wrap(jax.jacfwd, f)
 
 def jacrev(f):
-    """
-    Computes the Jacobian of a function `f` using reverse-mode differentiation.
-    
-    Works for vector-output functions. Efficient when input dimension > output dimension.
-    """
-    from jax import jacrev as jax_jacrev
-    def python_wrapper(x):
-        return f(x)
-    
-    return jax_jacrev(python_wrapper)
+    return wrap(jax.jacrev, f)
 
 def jacobian(f):
-    from jax import jacobian as jax_jacobian
-    def python_wrapper(x):
-        return f(x)
-    return jax_jacobian(python_wrapper)
+    return wrap(jax.jacobian, f)
 
 def jit(f):
-    """
-    Just-in-time compiles a function for faster execution.
-    
-    The first call will be slower due to compilation, but subsequent calls
-    with the same shapes will be much faster.
-    """
-    from jax import jit as jax_jit
-    def python_wrapper(*args):
-        return f(*args)
-    
-    return jax_jit(python_wrapper)
+    return wrap(jax.jit, f)
 
 def jit_fn(f, jit_kwargs=None):
-    """
-    Universal JIT wrapper that works with any function.
-    Accepts an optional dictionary of arguments to pass to jax.jit 
-    (e.g., static_argnums, donate_argnums, etc.).
-    """
-    from jax import jit as jax_jit
-    
-    # Handle default None case
-    if jit_kwargs is None:
-        jit_kwargs = {}
-
-    def python_wrapper(*args, **kwargs):
-        return f(*args, **kwargs)
-    
-    # Unpack the dictionary into jax.jit
-    return jax_jit(python_wrapper, **jit_kwargs)
+    return wrap(jax.jit, f, kwargs=jit_kwargs)

--- a/core/src/main/resources/python/jax_helper.py
+++ b/core/src/main/resources/python/jax_helper.py
@@ -8,6 +8,12 @@ import builtins
 builtins.jax = jax
 builtins.jnp = jnp
 
+def wrap_fn(f):
+    """Wrap a ScalaPy callback as a plain Python callable."""
+    def python_wrapper(*a, **kw):
+        return f(*a, **kw)
+    return python_wrapper
+
 def wrap(jax_transform, f, kwargs=None):
     """
     Generic wrapper that shields a ScalaPy function from JAX introspection,
@@ -19,11 +25,9 @@ def wrap(jax_transform, f, kwargs=None):
         wrap(jax.jit, f, kwargs={"donate_argnums": (0,)})
         wrap(jax.jacfwd, f)
     """
-    def python_wrapper(*a, **kw):
-        return f(*a, **kw)
     if kwargs:
-        return jax_transform(python_wrapper, **kwargs)
-    return jax_transform(python_wrapper)
+        return jax_transform(wrap_fn(f), **kwargs)
+    return jax_transform(wrap_fn(f))
 
 def vmap(f, dims):
     return wrap(jax.vmap, f, kwargs={"in_axes": dims})

--- a/core/src/main/scala/dimwit/python/PyBridge.scala
+++ b/core/src/main/scala/dimwit/python/PyBridge.scala
@@ -2,6 +2,8 @@ package dimwit.python
 
 import dimwit.tensor.*
 import dimwit.jax.Jax
+import dimwit.autodiff.TensorTree
+import dimwit.OnError
 import me.shadaj.scalapy.py
 
 object PyBridge:
@@ -16,3 +18,30 @@ object PyBridge:
 
   extension [T <: Tuple: Labels, V](tensor: Tensor[T, V])
     def applyPy(f: py.Dynamic): Tensor[T, V] = liftPyTensor(f(toPyTensor(tensor)))
+
+  // --- fromPython: wrap a Python callable for typed Scala use ---
+
+  def fromPython[In: TensorTree, Out: TensorTree](pyFunc: py.Dynamic): In => Out =
+    (in: In) =>
+      TensorTree[Out].fromPyTree(pyFunc(TensorTree[In].toPyTree(in)))
+
+  def fromPython[T1: TensorTree, T2: TensorTree, Out: TensorTree](pyFunc: py.Dynamic): (T1, T2) => Out =
+    val tupled = fromPython[(T1, T2), Out](pyFunc)
+    (t1, t2) => tupled((t1, t2))
+
+  def fromPython[T1: TensorTree, T2: TensorTree, T3: TensorTree, Out: TensorTree](pyFunc: py.Dynamic): (T1, T2, T3) => Out =
+    val tupled = fromPython[(T1, T2, T3), Out](pyFunc)
+    (t1, t2, t3) => tupled((t1, t2, t3))
+
+  def fromPython[T1: TensorTree, T2: TensorTree, T3: TensorTree, T4: TensorTree, Out: TensorTree](pyFunc: py.Dynamic): (T1, T2, T3, T4) => Out =
+    val tupled = fromPython[(T1, T2, T3, T4), Out](pyFunc)
+    (t1, t2, t3, t4) => tupled((t1, t2, t3, t4))
+
+  // --- toJax: wrap a Scala function through a JAX transform ---
+
+  def toJax[In: TensorTree, Out: TensorTree](jaxTransform: py.Dynamic)(f: In => Out): In => Out =
+    val fpy = (pyIn: Jax.PyDynamic) =>
+      OnError.traceStack:
+        TensorTree[Out].toPyTree(f(TensorTree[In].fromPyTree(pyIn)))
+    val transformed = Jax.jax_helper.wrap(jaxTransform, fpy, py.None)
+    fromPython[In, Out](transformed)

--- a/core/src/main/scala/dimwit/python/PyBridge.scala
+++ b/core/src/main/scala/dimwit/python/PyBridge.scala
@@ -19,23 +19,40 @@ object PyBridge:
   extension [T <: Tuple: Labels, V](tensor: Tensor[T, V])
     def applyPy(f: py.Dynamic): Tensor[T, V] = liftPyTensor(f(toPyTensor(tensor)))
 
-  // --- fromPython: wrap a Python callable for typed Scala use ---
+  // --- liftPyFn: wrap a Python callable for typed Scala use ---
 
-  def fromPython[In: TensorTree, Out: TensorTree](pyFunc: py.Dynamic): In => Out =
+  def liftPyFn[In: TensorTree, Out: TensorTree](pyFunc: py.Dynamic): In => Out =
     (in: In) =>
       TensorTree[Out].fromPyTree(pyFunc(TensorTree[In].toPyTree(in)))
 
-  def fromPython[T1: TensorTree, T2: TensorTree, Out: TensorTree](pyFunc: py.Dynamic): (T1, T2) => Out =
-    val tupled = fromPython[(T1, T2), Out](pyFunc)
+  def liftPyFn[T1: TensorTree, T2: TensorTree, Out: TensorTree](pyFunc: py.Dynamic): (T1, T2) => Out =
+    val tupled = liftPyFn[(T1, T2), Out](pyFunc)
     (t1, t2) => tupled((t1, t2))
 
-  def fromPython[T1: TensorTree, T2: TensorTree, T3: TensorTree, Out: TensorTree](pyFunc: py.Dynamic): (T1, T2, T3) => Out =
-    val tupled = fromPython[(T1, T2, T3), Out](pyFunc)
+  def liftPyFn[T1: TensorTree, T2: TensorTree, T3: TensorTree, Out: TensorTree](pyFunc: py.Dynamic): (T1, T2, T3) => Out =
+    val tupled = liftPyFn[(T1, T2, T3), Out](pyFunc)
     (t1, t2, t3) => tupled((t1, t2, t3))
 
-  def fromPython[T1: TensorTree, T2: TensorTree, T3: TensorTree, T4: TensorTree, Out: TensorTree](pyFunc: py.Dynamic): (T1, T2, T3, T4) => Out =
-    val tupled = fromPython[(T1, T2, T3, T4), Out](pyFunc)
+  def liftPyFn[T1: TensorTree, T2: TensorTree, T3: TensorTree, T4: TensorTree, Out: TensorTree](pyFunc: py.Dynamic): (T1, T2, T3, T4) => Out =
+    val tupled = liftPyFn[(T1, T2, T3, T4), Out](pyFunc)
     (t1, t2, t3, t4) => tupled((t1, t2, t3, t4))
+
+  // --- toPyFn: wrap a Scala function as a Python-callable py.Dynamic ---
+
+  /** Wrap a Scala `In => Out` as a `py.Dynamic` callable that operates on JAX pytrees.
+    *
+    * This is the "Python-side handle" counterpart of `toJax`: it does the same `fromPyTree` → f → `toPyTree`
+    * plumbing but returns the raw `py.Dynamic` instead of re-wrapping back into a typed Scala function.
+    *
+    * Useful when a Python library (e.g. BlackJAX) needs a Python-callable function.
+    */
+  def toPyFn[In: TensorTree, Out: TensorTree](f: In => Out): py.Dynamic =
+    val ttIn = TensorTree[In]
+    val ttOut = TensorTree[Out]
+    Jax.jax_helper.wrap_fn { (pyIn: Jax.PyDynamic) =>
+      OnError.traceStack:
+        ttOut.toPyTree(f(ttIn.fromPyTree(pyIn)))
+    }
 
   // --- toJax: wrap a Scala function through a JAX transform ---
 
@@ -44,4 +61,4 @@ object PyBridge:
       OnError.traceStack:
         TensorTree[Out].toPyTree(f(TensorTree[In].fromPyTree(pyIn)))
     val transformed = Jax.jax_helper.wrap(jaxTransform, fpy, py.None)
-    fromPython[In, Out](transformed)
+    liftPyFn[In, Out](transformed)

--- a/core/src/test/scala/dimwit/python/PyWrapSuite.scala
+++ b/core/src/test/scala/dimwit/python/PyWrapSuite.scala
@@ -15,24 +15,24 @@ class PyWrapSuite extends AnyFunSpec with Matchers:
   private val addTupled = py.eval("lambda args: args[0] + args[1]")
   private val squareScalar = py.eval("lambda x: x * x")
 
-  describe("PyBridge.fromPython"):
+  describe("PyBridge.liftPyFn"):
 
     describe("1-input function"):
       it("wraps an identity Python function"):
-        val f = PyBridge.fromPython[Tensor1[A, Float], Tensor1[A, Float]](identity1d)
+        val f = PyBridge.liftPyFn[Tensor1[A, Float], Tensor1[A, Float]](identity1d)
         val input = Tensor1(Axis[A]).fromArray(Array(1f, 2f, 3f))
 
         f(input) should approxEqual(input)
 
       it("wraps a Python function that doubles output"):
-        val f = PyBridge.fromPython[Tensor1[A, Float], Tensor1[A, Float]](double1d)
+        val f = PyBridge.liftPyFn[Tensor1[A, Float], Tensor1[A, Float]](double1d)
         val input = Tensor1(Axis[A]).fromArray(Array(1f, 2f, 3f))
 
         f(input) should approxEqual(Tensor1(Axis[A]).fromArray(Array(2f, 4f, 6f)))
 
     describe("2-input function"):
       it("wraps a Python function that adds two tensors"):
-        val f = PyBridge.fromPython[(Tensor1[A, Float], Tensor1[A, Float]), Tensor1[A, Float]](addTupled)
+        val f = PyBridge.liftPyFn[(Tensor1[A, Float], Tensor1[A, Float]), Tensor1[A, Float]](addTupled)
         val t1 = Tensor1(Axis[A]).fromArray(Array(1f, 2f, 3f))
         val t2 = Tensor1(Axis[A]).fromArray(Array(4f, 5f, 6f))
 
@@ -40,7 +40,7 @@ class PyWrapSuite extends AnyFunSpec with Matchers:
 
     describe("scalar function"):
       it("wraps a Python function that squares a scalar"):
-        val f = PyBridge.fromPython[Tensor0[Float], Tensor0[Float]](squareScalar)
+        val f = PyBridge.liftPyFn[Tensor0[Float], Tensor0[Float]](squareScalar)
         val x = Tensor0(5.0f)
 
         f(x) shouldEqual Tensor0(25.0f)
@@ -53,3 +53,34 @@ class PyWrapSuite extends AnyFunSpec with Matchers:
       val input = Tensor1(Axis[A]).fromArray(Array(1f, 2f, 3f))
 
       jitted(input) should approxEqual(f(input))
+
+  describe("PyBridge.toPyFn"):
+    it("wraps a Scala function as a Python-callable that doubles a tensor"):
+      def double(t: Tensor1[A, Float]): Tensor1[A, Float] = t *! 2f
+
+      val pyFn = PyBridge.toPyFn[Tensor1[A, Float], Tensor1[A, Float]](double)
+      val input = Tensor1(Axis[A]).fromArray(Array(1f, 2f, 3f))
+      val result = PyBridge.liftPyFn[Tensor1[A, Float], Tensor1[A, Float]](pyFn)(input)
+
+      result should approxEqual(Tensor1(Axis[A]).fromArray(Array(2f, 4f, 6f)))
+
+    it("wraps a Scala function that returns a scalar"):
+      def sumAll(t: Tensor1[A, Float]): Tensor0[Float] = t.sum
+
+      val pyFn = PyBridge.toPyFn[Tensor1[A, Float], Tensor0[Float]](sumAll)
+      val input = Tensor1(Axis[A]).fromArray(Array(1f, 2f, 3f))
+      val result = PyBridge.liftPyFn[Tensor1[A, Float], Tensor0[Float]](pyFn)(input)
+
+      result shouldEqual Tensor0(6.0f)
+
+    it("produces a py.Dynamic usable from Python code"):
+      def triple(t: Tensor1[A, Float]): Tensor1[A, Float] = t *! 3f
+
+      val pyFn = PyBridge.toPyFn[Tensor1[A, Float], Tensor1[A, Float]](triple)
+      // Call through a Python lambda that just forwards to pyFn
+      val caller = py.eval("lambda fn, x: fn(x)")
+      val input = Tensor1(Axis[A]).fromArray(Array(2f, 3f, 4f))
+      val pyResult = caller(pyFn, dimwit.autodiff.TensorTree[Tensor1[A, Float]].toPyTree(input))
+      val result = dimwit.autodiff.TensorTree[Tensor1[A, Float]].fromPyTree(pyResult)
+
+      result should approxEqual(Tensor1(Axis[A]).fromArray(Array(6f, 9f, 12f)))

--- a/core/src/test/scala/dimwit/python/PyWrapSuite.scala
+++ b/core/src/test/scala/dimwit/python/PyWrapSuite.scala
@@ -1,0 +1,55 @@
+package dimwit.python
+
+import dimwit.*
+import dimwit.Conversions.given
+import dimwit.python.PyBridge
+import dimwit.jax.Jax
+import me.shadaj.scalapy.py
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+class PyWrapSuite extends AnyFunSpec with Matchers:
+
+  private val identity1d = py.eval("lambda x: x")
+  private val double1d = py.eval("lambda x: __import__('jax').tree.map(lambda v: v * 2, x)")
+  private val addTupled = py.eval("lambda args: args[0] + args[1]")
+  private val squareScalar = py.eval("lambda x: x * x")
+
+  describe("PyBridge.fromPython"):
+
+    describe("1-input function"):
+      it("wraps an identity Python function"):
+        val f = PyBridge.fromPython[Tensor1[A, Float], Tensor1[A, Float]](identity1d)
+        val input = Tensor1(Axis[A]).fromArray(Array(1f, 2f, 3f))
+
+        f(input) should approxEqual(input)
+
+      it("wraps a Python function that doubles output"):
+        val f = PyBridge.fromPython[Tensor1[A, Float], Tensor1[A, Float]](double1d)
+        val input = Tensor1(Axis[A]).fromArray(Array(1f, 2f, 3f))
+
+        f(input) should approxEqual(Tensor1(Axis[A]).fromArray(Array(2f, 4f, 6f)))
+
+    describe("2-input function"):
+      it("wraps a Python function that adds two tensors"):
+        val f = PyBridge.fromPython[(Tensor1[A, Float], Tensor1[A, Float]), Tensor1[A, Float]](addTupled)
+        val t1 = Tensor1(Axis[A]).fromArray(Array(1f, 2f, 3f))
+        val t2 = Tensor1(Axis[A]).fromArray(Array(4f, 5f, 6f))
+
+        f((t1, t2)) should approxEqual(Tensor1(Axis[A]).fromArray(Array(5f, 7f, 9f)))
+
+    describe("scalar function"):
+      it("wraps a Python function that squares a scalar"):
+        val f = PyBridge.fromPython[Tensor0[Float], Tensor0[Float]](squareScalar)
+        val x = Tensor0(5.0f)
+
+        f(x) shouldEqual Tensor0(25.0f)
+
+  describe("PyBridge.toJax"):
+    it("applies jax.jit to a Scala function"):
+      def f(t: Tensor1[A, Float]): Tensor1[A, Float] = t *! 3f
+
+      val jitted = PyBridge.toJax[Tensor1[A, Float], Tensor1[A, Float]](Jax.jax.jit)(f)
+      val input = Tensor1(Axis[A]).fromArray(Array(1f, 2f, 3f))
+
+      jitted(input) should approxEqual(f(input))


### PR DESCRIPTION
Dimwit provides facilities in the module `python_helpers`  that provide functionality to make scala function save for use in a jax tracer and to call Python functions using dimwit tensors. Currently these functions are only used internally and there is no easy to use api.  However, using this mechanism could also be useful in libraries that use dimwit. This PR proposes to add corresponding methods  to `PyBridge`. 