### PR TITLE
implement a split method to split tensors

### DIFF
--- a/core/src/main/scala/dimwit/tensor/Axis.scala
+++ b/core/src/main/scala/dimwit/tensor/Axis.scala
@@ -15,6 +15,8 @@ sealed trait AxisSelector[L]:
 case class AxisAtIndex[L](axis: Axis[L], index: Int) extends AxisSelector[L]
 case class AxisAtRange[L](axis: Axis[L], range: Range) extends AxisSelector[L]
 case class AxisAtIndices[L](axis: Axis[L], indices: Seq[Int]) extends AxisSelector[L]
+case class AxisAtTupleIndices[L, I <: NonEmptyTuple](axis: Axis[L], indices: I) extends AxisSelector[L]
+
 case class AxisAtTensorIndex[L](axis: Axis[L], index: Tensor0[Int]) extends AxisSelector[L]
 
 object Axis:
@@ -26,6 +28,7 @@ sealed trait Axis[A]:
   def extent(size: Int): AxisExtent[A] = AxisExtent(this, size)
   def ->(size: Int): AxisExtent[A] = this.extent(size)
   def at(index: Int): AxisAtIndex[A] = AxisAtIndex(this, index)
+  def at[I <: NonEmptyTuple](indices: I): AxisAtTupleIndices[A, I] = AxisAtTupleIndices(this, indices)
   def at(range: Range): AxisAtRange[A] = AxisAtRange(this, range)
   def at(indices: Seq[Int]): AxisAtIndices[A] = AxisAtIndices(this, indices)
   def at(index: Tensor0[Int]): AxisAtTensorIndex[A] = AxisAtTensorIndex(this, index)

--- a/core/src/main/scala/dimwit/tensor/TensorOps.scala
+++ b/core/src/main/scala/dimwit/tensor/TensorOps.scala
@@ -564,10 +564,11 @@ object TensorOps:
 
       type SliceIndex = Int | List[Int] | Range | Tensor0[Int]
       type ExtractLabel[X] = X match
-        case AxisAtIndex[l]       => l
-        case AxisAtRange[l]       => l
-        case AxisAtIndices[l]     => l
-        case AxisAtTensorIndex[l] => l
+        case AxisAtIndex[l]            => l
+        case AxisAtRange[l]            => l
+        case AxisAtIndices[l]          => l
+        case AxisAtTupleIndices[l, ?]  => l
+        case AxisAtTensorIndex[l]      => l
       type ExtractLabels[Inputs <: Tuple] = Tuple.Map[Inputs, ExtractLabel]
 
       trait SliceLabelExtractor[Inputs <: Tuple, Out <: Tuple]
@@ -593,6 +594,11 @@ object TensorOps:
         ): SliceLabelExtractor[AxisAtIndices[L] *: Tail, TailOut] =
           new SliceLabelExtractor[AxisAtIndices[L] *: Tail, TailOut] {}
 
+        given consAxisAtTupleIndices[L, I <: NonEmptyTuple, Tail <: Tuple, TailOut <: Tuple](using
+            tailExt: SliceLabelExtractor[Tail, TailOut]
+        ): SliceLabelExtractor[AxisAtTupleIndices[L, I] *: Tail, TailOut] =
+          new SliceLabelExtractor[AxisAtTupleIndices[L, I] *: Tail, TailOut] {}
+
         given consAxisAtTensorIndex[L, Tail <: Tuple, TailOut <: Tuple](using
             tailExt: SliceLabelExtractor[Tail, TailOut]
         ): SliceLabelExtractor[AxisAtTensorIndex[L] *: Tail, L *: TailOut] =
@@ -613,6 +619,8 @@ object TensorOps:
             tailExt: SliceLabelExtractor[Tail, TailOut]
         ): SliceLabelExtractor[(Axis[L], SeqT) *: Tail, TailOut] =
           new SliceLabelExtractor[(Axis[L], SeqT) *: Tail, TailOut] {}
+
+  
 
       type Swap[T <: Tuple, A, B] <: Tuple = T match
         case EmptyTuple => EmptyTuple
@@ -719,6 +727,10 @@ object TensorOps:
       val jaxValues = List(t1.jaxValue, t2.jaxValue).toPythonProxy
       Tensor(Jax.jnp.concatenate(jaxValues, axis = canConcat.index))
 
+    type SplitComponents[L, I <: Tuple] <: Tuple = I match
+      case EmptyTuple => L *: EmptyTuple
+      case _ *: tail  => L *: SplitComponents[L, tail]
+
     trait Deconcatenator[L]:
       type Components <: Tuple
       def labels: List[Label[?]]
@@ -796,6 +808,36 @@ object TensorOps:
 
         maker.apply(splitArrays, decon.labels, originalNames, axisIndex.index)
 
+      /** Splits the tensor along the specified axis at the given indices, returning a tuple of tensors corresponding to the splits.
+        *
+        * @param selector of the form Axis[L].at((idx1, idx2, ...)) specifying the axis to split and the indices to split at
+        * @return the tuple of tensors resulting from the split
+        */
+      def split[L: Label, I <: NonEmptyTuple](selector: AxisAtTupleIndices[L, I])(using
+          axisIndex: AxisIndex[T, L],
+          maker: TensorTupleMaker[SplitComponents[L, I], T, L, V],
+          labels: Labels[T]
+      ): maker.Out =
+        val splitList = selector.indices.toList.asInstanceOf[List[Int]]
+        val pyIndices = me.shadaj.scalapy.py.Dynamic.global.list(splitList.toPythonProxy)
+        val splitArrays = Jax.jnp.split(tensor.jaxValue, pyIndices, axis = axisIndex.index).as[Seq[Jax.PyDynamic]]
+        val axisLabelInstance = summon[Label[L]]
+        val compLabels = List.fill(splitList.size + 1)(axisLabelInstance.asInstanceOf[Label[?]])
+        maker.apply(splitArrays, compLabels, labels.names.toSeq, axisIndex.index)
+
+      /** Splits the tensor along the specified axis at the given index,
+        * returning a tuple of two tensors corresponding to the splits.
+        *
+        * @param selector of the form Axis[L].at(idx) specifying the axis to split and the index to split at
+        * @return a tuple of two tensors resulting from the split
+        */
+      def split[L: Label](selector: AxisAtIndex[L])(using
+          axisIndex: AxisIndex[T, L],
+          maker: TensorTupleMaker[L *: L *: EmptyTuple, T, L, V],
+          labels: Labels[T]
+      ): maker.Out =
+        split(AxisAtTupleIndices(selector.axis, Tuple1(selector.index)))
+
       private def calcPyIndices[Inputs <: Tuple](
           inputs: Inputs,
           targetDims: List[Int]
@@ -818,6 +860,8 @@ object TensorOps:
               indicesBuffer(dimIndex) = PySlice(range.head, range.last + 1, range.step)
             case AxisAtIndices(_, indices) =>
               indicesBuffer(dimIndex) = indices.map(py.Any.from).toPythonCopy // TODO find out why Copy is needed here
+            case AxisAtTupleIndices(_, indices) =>
+              indicesBuffer(dimIndex) = indices.toList.asInstanceOf[List[Int]].map(py.Any.from).toPythonCopy
             case AxisAtTensorIndex(_, tensorIdx) =>
               indicesBuffer(dimIndex) = tensorIdx.jaxValue
             // Backward compatibility with tuples
@@ -835,6 +879,50 @@ object TensorOps:
 
         Jax.Dynamic.global.tuple(indicesBuffer.toSeq.toPythonProxy)
 
+      /** Flattens all axes of the tensor into a single axis.
+        * The resulting tensor will have a single axis named by concatenating the original axis names with "*".
+        *
+        * @return a Tensor1 with the merged axis
+        */
+      def flatten(using labels: Labels[T]): Tensor1[MergeLabels[T], V] =
+        given Labels[Tuple1[MergeLabels[T]]] with
+          def names = List(summon[Labels[T]].names.mkString("*"))
+        Tensor(Jax.jnp.ravel(tensor.jaxValue))
+
+      /** Flattens the specified axes of the tensor into a single axis.
+        * The resulting tensor will have the specified axes merged into a single axis named by concatenating the original axis names with "*"
+        * The other axes remain unchanged.
+        *
+        * @param axes the axes to flatten, specified as a tuple of Axis (e.g. (Axis[Ax1], Axis[Ax2]))
+        * @return a Tensor with the specified axes merged into a single axis
+        */
+      def flatten[AxesTuple <: Tuple, R <: Tuple](
+          axes: AxesTuple
+      )(using
+          merger: AxesMerger.Aux[T, UnwrapAxes[AxesTuple], R],
+          labels: Labels[R]
+      ): Tensor[R, V] =
+        val permuted = Jax.jnp.transpose(tensor.jaxValue, merger.permutation.toPythonProxy)
+
+        val originalDims = tensor.shape.dimensions
+        val mergedSize = merger.mergeIndices.map(originalDims).product
+
+        val remainingDims = originalDims.zipWithIndex
+          .filterNot((d, i) => merger.mergeIndices.contains(i))
+          .map(_._1)
+
+        val newDimensions = remainingDims.patch(merger.mergedIndex, Seq(mergedSize), 0)
+
+        Tensor(Jax.jnp.reshape(permuted, newDimensions.toPythonProxy))
+
+      /** Unflattens splitAxis into a new shape specified by newShape. The other axes remain unchanged.
+        *
+        * The user must ensure that the size of splitAxis matches the product of the dimensions in newShape, otherwise a runtime error will occur.
+        *
+        * @param splitAxis the axis to unflatten
+        * @param newShape the new shape to unflatten into, specified as a Shape
+        * @return a Tensor with the specified axis unflattened into the new shape
+        */
       def unflatten[SplitL, NewT <: Tuple, R <: Tuple](
           splitAxis: Axis[SplitL],
           newShape: Shape[NewT]
@@ -854,6 +942,13 @@ object TensorOps:
           )
         )
 
+      /** Unflattens the tensor into a new shape specified by newShape.
+        *
+        * The user must ensure that the size of the tensor matches the product of the dimensions in newShape, otherwise a runtime error will occur.
+        *
+        * @param newShape the new shape to unflatten into, specified as a Shape
+        * @return a Tensor with the new shape
+        */
       def unflatten[NewT <: Tuple: Labels](
           newShape: Shape[NewT]
       )(using
@@ -878,31 +973,6 @@ object TensorOps:
       ): Tensor[UnwrapAxes[NewOrder], V] =
         val indices = ev.indices
         Tensor(Jax.jnp.transpose(tensor.jaxValue, indices.toPythonProxy))
-
-      // merge all tensor axes to a single vector axis
-      def flatten(using labels: Labels[T]): Tensor1[MergeLabels[T], V] =
-        given Labels[Tuple1[MergeLabels[T]]] with
-          def names = List(summon[Labels[T]].names.mkString("*"))
-        Tensor(Jax.jnp.ravel(tensor.jaxValue))
-
-      def flatten[ToMerge <: Tuple, R <: Tuple](
-          axes: ToMerge
-      )(using
-          merger: AxesMerger.Aux[T, UnwrapAxes[ToMerge], R],
-          labels: Labels[R]
-      ): Tensor[R, V] =
-        val permuted = Jax.jnp.transpose(tensor.jaxValue, merger.permutation.toPythonProxy)
-
-        val originalDims = tensor.shape.dimensions
-        val mergedSize = merger.mergeIndices.map(originalDims).product
-
-        val remainingDims = originalDims.zipWithIndex
-          .filterNot((d, i) => merger.mergeIndices.contains(i))
-          .map(_._1)
-
-        val newDimensions = remainingDims.patch(merger.mergedIndex, Seq(mergedSize), 0)
-
-        Tensor(Jax.jnp.reshape(permuted, newDimensions.toPythonProxy))
 
       def chunk[splitL: Label](splitAxis: Axis[splitL], chunkSize: Int)(using
           labels: Labels[T],
@@ -954,6 +1024,15 @@ object TensorOps:
       )(using
           sliceExtractor: SliceLabelExtractor[Tuple1[AxisAtTensorIndex[L]], LabelsToRemove],
           ev: AxesConditionalRemover[T, LabelsToRemove, ExtractLabels[Tuple1[AxisAtTensorIndex[L]]], R],
+          labels: Labels[R]
+      ): Tensor[R, V] = slice(Tuple1(selector))
+
+      // Convenience overload for AxisAtTupleIndices
+      def slice[L, U <: NonEmptyTuple, LabelsToRemove <: Tuple, R <: Tuple](
+          selector: AxisAtTupleIndices[L, U]
+      )(using
+          sliceExtractor: SliceLabelExtractor[Tuple1[AxisAtTupleIndices[L, U]], LabelsToRemove],
+          ev: AxesConditionalRemover[T, LabelsToRemove, ExtractLabels[Tuple1[AxisAtTupleIndices[L, U]]], R],
           labels: Labels[R]
       ): Tensor[R, V] = slice(Tuple1(selector))
 

--- a/core/src/main/scala/dimwit/tensor/TensorOps.scala
+++ b/core/src/main/scala/dimwit/tensor/TensorOps.scala
@@ -564,11 +564,11 @@ object TensorOps:
 
       type SliceIndex = Int | List[Int] | Range | Tensor0[Int]
       type ExtractLabel[X] = X match
-        case AxisAtIndex[l]            => l
-        case AxisAtRange[l]            => l
-        case AxisAtIndices[l]          => l
-        case AxisAtTupleIndices[l, ?]  => l
-        case AxisAtTensorIndex[l]      => l
+        case AxisAtIndex[l]           => l
+        case AxisAtRange[l]           => l
+        case AxisAtIndices[l]         => l
+        case AxisAtTupleIndices[l, ?] => l
+        case AxisAtTensorIndex[l]     => l
       type ExtractLabels[Inputs <: Tuple] = Tuple.Map[Inputs, ExtractLabel]
 
       trait SliceLabelExtractor[Inputs <: Tuple, Out <: Tuple]
@@ -619,8 +619,6 @@ object TensorOps:
             tailExt: SliceLabelExtractor[Tail, TailOut]
         ): SliceLabelExtractor[(Axis[L], SeqT) *: Tail, TailOut] =
           new SliceLabelExtractor[(Axis[L], SeqT) *: Tail, TailOut] {}
-
-  
 
       type Swap[T <: Tuple, A, B] <: Tuple = T match
         case EmptyTuple => EmptyTuple

--- a/core/src/test/scala/dimwit/tensor/TensorOpsStructureSuite.scala
+++ b/core/src/test/scala/dimwit/tensor/TensorOpsStructureSuite.scala
@@ -362,6 +362,37 @@ class TensorOpsStructureSuite extends AnyFunSpec with Matchers:
       partC.axes shouldBe List("A", "C")
       concatenate(partB, partC) shouldEqual t
 
+  describe("split function"):
+
+    it("split into 2 parts"):
+      val t = Tensor2(Axis[A], Axis[B]).fromArray(
+        Array(Array(1.0f, 2.0f, 3.0f, 4.0f, 5.0f))
+      )
+      val (part1, part2) = t.split(Axis[B].at(2))
+      part1.axes shouldBe List("A", "B")
+      part2.axes shouldBe List("A", "B")
+      part1.shape(Axis[B]) shouldBe 2
+      part2.shape(Axis[B]) shouldBe 3
+
+    it("split into 3 parts"):
+      val t = Tensor1(Axis[A]).fromArray(Array(1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f))
+      val (part1, part2, part3) = t.split(Axis[A].at((2, 3)))
+      part1.shape(Axis[A]) shouldBe 2
+      part2.shape(Axis[A]) shouldBe 1
+      part3.shape(Axis[A]) shouldBe 3
+
+    it("split is inverse of concatenate"):
+      val part1 = Tensor2(Axis[A], Axis[B]).fromArray(Array(Array(1.0f, 2.0f)))
+      val part2 = Tensor2(Axis[A], Axis[B]).fromArray(Array(Array(3.0f, 4.0f)))
+      val part3 = Tensor2(Axis[A], Axis[B]).fromArray(Array(Array(5.0f, 6.0f)))
+      val joined = concatenate(Seq(part1, part2, part3), Axis[B])
+      val n1 = part1.shape(Axis[B])
+      val n2 = part2.shape(Axis[B])
+      val (s1, s2, s3) = joined.split(Axis[B].at((n1, n1 + n2)))
+      s1 should approxEqual(part1)
+      s2 should approxEqual(part2)
+      s3 should approxEqual(part3)
+
   describe("set function"):
 
     describe("AxisAtIndex"):


### PR DESCRIPTION
This PR proposes to add a method `split`  which splits a tensor along a given axis. It is the inverse of a concatenation along a given axis. 

The syntax is designed to work like `slice` and uses the `AxesSelectors`, which were extended to accept also tuples as arguments. To split a tensor `t : Tensor2[A,B, Float]`  in 2 parts we can write
```scala 
t.split(Axis[A].at(1))
```
and to split it in 3 parts we write
```scala 
t.split(Axis[A].at((1, 3))
```
A new convenience overload was added to `slice` to accept tuples as axis indices. 