### PR TITLE
simplify package imort and Key usage

### DIFF
--- a/core/src/main/scala/dimwit/autodiff/package.scala
+++ b/core/src/main/scala/dimwit/autodiff/package.scala
@@ -1,0 +1,3 @@
+package dimwit.autodiff
+
+export Autodiff.*

--- a/core/src/main/scala/dimwit/package.scala
+++ b/core/src/main/scala/dimwit/package.scala
@@ -83,20 +83,17 @@ package object dimwit:
 
   // Export devices
   export dimwit.hardware.Device
-
   // Export automatic differentiation
   export dimwit.autodiff.{Autodiff, TensorTree, FloatTree, Grad}
-  export dimwit.autodiff.FloatTree.*
-
   // Export Just-in-Time compilation
   export dimwit.jax.Jit.{jit, jitDonating, jitDonatingUnsafe}
   export dimwit.jax.EagerCleanup.eagerCleanup
 
   object Conversions:
     export dimwit.tensor.Tensor0.{float2FloatTensor, int2IntTensor, int2FloatTensor, boolean2BooleanTensor}
-
   // Export random object
   export dimwit.random.Random
+  export dimwit.random.Random.Key
 
   // export some stats types
   export dimwit.stats.{Prob, LogProb}

--- a/core/src/main/scala/dimwit/stats/UnivariateDistributions.scala
+++ b/core/src/main/scala/dimwit/stats/UnivariateDistributions.scala
@@ -1,6 +1,7 @@
 package dimwit.stats
 
 import dimwit.*
+import dimwit.random.*
 import dimwit.jax.Jax
 import dimwit.python.PyBridge.liftPyTensor
 
@@ -19,7 +20,7 @@ class Categorical[L: Label](val probs: Tensor1[L, Prob]) extends UnivariateDistr
   override def logProb(x: Tensor0[Int]): Tensor0[LogProb] =
     liftPyTensor(logProbs.jaxValue.__getitem__(x.jaxValue))
 
-  override def sample(key: Random.Key): Tensor0[Int] =
+  override def sample(key: Key): Tensor0[Int] =
     liftPyTensor(Jax.jrandom.categorical(key.jaxKey, logProbs.jaxValue))
 
 object Categorical:

--- a/examples/src/main/scala/basic/Autoencoder.scala
+++ b/examples/src/main/scala/basic/Autoencoder.scala
@@ -12,7 +12,7 @@ import nn.GradientDescent
 import dimwit.jax.Jax
 import nn.ActivationFunctions.sigmoid
 import dimwit.random.Random.Key
-
+import dimwit.autodiff.*
 import examples.dataset.MNISTLoader
 
 import MNISTLoader.{Sample, TrainSample, TestSample, Height, Width}
@@ -169,7 +169,7 @@ object AutoencoderExample:
     val optimizer = GradientDescent(learningRate = Tensor0(learningRate))
 
     def gradientStep(batch: Tensor3[TrainSample, Height, Width, Float], params: Autoencoder.Params): Autoencoder.Params =
-      val grads = Autodiff.grad(loss(batch))(params)
+      val grads = grad(loss(batch))(params)
       val (newParams, _) = optimizer.update(grads, params, ())
       newParams
 

--- a/examples/src/main/scala/basic/LogisticRegression.scala
+++ b/examples/src/main/scala/basic/LogisticRegression.scala
@@ -1,6 +1,7 @@
 package examples.basic
 
 import dimwit.*
+import dimwit.autodiff.*
 import dimwit.Conversions.given
 import nn.*
 import nn.ActivationFunctions.{sigmoid, relu}
@@ -125,7 +126,7 @@ object LogisticRegression:
 
     // Training loop
     val numiterations = 1000
-    val trainTrajectory = gd.iterate(initParams)(Autodiff.grad(trainLoss))
+    val trainTrajectory = gd.iterate(initParams)(grad(trainLoss))
     val finalParams = trainTrajectory.zipWithIndex
       .tapEach:
         case (params, index) =>

--- a/examples/src/main/scala/basic/MLClassifierMNist.scala
+++ b/examples/src/main/scala/basic/MLClassifierMNist.scala
@@ -1,6 +1,7 @@
 package examples.basic
 
 import dimwit.*
+import dimwit.autodiff.*
 import dimwit.Conversions.given
 import nn.*
 import nn.ActivationFunctions.{relu, sigmoid}
@@ -109,7 +110,7 @@ object MLPClassifierMNist:
         state: OptState
     ): (MLP.Params, OptState) =
       val lossBatch = batchLoss(imageBatch, labelBatch)
-      val grads = Autodiff.grad(lossBatch)(params)
+      val grads = grad(lossBatch)(params)
       optimizer.update(grads, params, state)
     val (jitDonate, jitStep, jitReclaim) = jitDonating(gradientStep)
 

--- a/examples/src/main/scala/basic/Playground.scala
+++ b/examples/src/main/scala/basic/Playground.scala
@@ -1,0 +1,15 @@
+package src.main.scala.basic
+
+import dimwit.*
+import dimwit.autodiff.*
+
+object Playground extends App:
+  val k = Key(42)
+
+  trait A derives Label
+  trait B derives Label
+
+  def f(x: Tensor1[A, Float]): Tensor0[Float] =
+    x.sum
+
+  grad(f)

--- a/examples/src/main/scala/complex/VariationalAutoencoder.scala
+++ b/examples/src/main/scala/complex/VariationalAutoencoder.scala
@@ -3,6 +3,7 @@ package examples.complex.vae
 import examples.timed
 
 import dimwit.*
+import dimwit.autodiff.*
 import dimwit.Conversions.given
 import dimwit.stats.Normal
 import dimwit.random.Random
@@ -181,7 +182,7 @@ object VariationalAutoencoderExample:
     val batches = trainImages.chunk(Axis[TrainSample], numSamples / batchSize)
     val optimizer = GradientDescent(learningRate = Tensor0(learningRate))
     def trainBatch(trainKey: Random.Key, batch: Tensor3[TrainSample, Height, Width, Float], params: Params): Params =
-      val grads = Autodiff.grad(batchLoss(trainKey, batch))(params)
+      val grads = grad(batchLoss(trainKey, batch))(params)
       val (newParams, _) = optimizer.update(grads, params, ())
       newParams
 

--- a/nn/src/main/scala/nn/GradientOptimizer.scala
+++ b/nn/src/main/scala/nn/GradientOptimizer.scala
@@ -3,7 +3,7 @@ package nn
 import dimwit.*
 import dimwit.Conversions.given
 import dimwit.autodiff.FloatTree.ops.*
-import dimwit.autodiff.Grad
+import dimwit.autodiff.*
 import dimwit.jax.Jax
 import dimwit.jax.Jit
 


### PR DESCRIPTION
Introduce package object for Autodiff such that
`import dimwit.autodiff.*` 
imports everything needed for autodiff.
This is in line with other imports in dimwit, such as 
`import dimwit.stats.*`. 

Furthermore the random Key type is made available with `dimwit.import.*` as it is omnipresent in dimwit and writing `Random.Key` is non-intuitive and verbose. 