### PR TITLE
Change seed passed to Key from Int to Long

### DIFF
--- a/core/src/main/scala/dimwit/random/Random.scala
+++ b/core/src/main/scala/dimwit/random/Random.scala
@@ -103,7 +103,7 @@ object Random:
       def fromPyTree(pyVal: Jax.PyAny): Key = Key(pyVal.as[Jax.PyDynamic])
 
     /** Create a random key from an integer seed */
-    def apply(seed: Int): Key = Key(Jax.jrandom.key(seed))
+    def apply(seed: Long): Key = Key(Jax.jrandom.key(seed))
 
     /** Create a random key from current time */
     def fromTime(): Key = Key(System.currentTimeMillis().toInt)


### PR DESCRIPTION
Random seeds in Java and Python are usually of type `Long` and not `Int`. This non-breaking change makes dimwit adhere to this standard. 