### PR TITLE
add zipvmap extension method for zipping 2 tensors

### DIFF
--- a/core/src/main/scala/dimwit/tensor/TensorOps.scala
+++ b/core/src/main/scala/dimwit/tensor/TensorOps.scala
@@ -29,6 +29,8 @@ import dimwit.OnError
 import Tuple.:*
 import Tuple.++
 import dimwit.tensor.ShapeTypeHelpers.MergeLabels
+import dimwit.tensor.TensorOps.Functional.ZipVmap.ShapesOf
+import dimwit.tensor.TensorOps.Functional.ZipVmap.TensorsOf
 
 object TensorOps:
 
@@ -1361,6 +1363,15 @@ object TensorOps:
             t.jaxValue
           )
         )
+
+      def zipvmap[L: Label, T2 <: Tuple, R <: Tuple, OutShape <: Tuple: Labels, OutV](axis: Axis[L])(
+          other: Tensor[T2, V]
+      )(using
+          ev: SharedAxisRemover[(T, T2), L, R]
+      )(
+          f: TensorsOf[R, (V, V)] => Tensor[OutShape, OutV]
+      ): Tensor[L *: OutShape, OutV] =
+        ZipVmap.zipvmap(axis)(t, other)(f)
 
       def vreduce[L: Label, R <: Tuple](
           axis: Axis[L]

--- a/core/src/test/scala/dimwit/tensor/TensorOpsFunctionalSuite.scala
+++ b/core/src/test/scala/dimwit/tensor/TensorOpsFunctionalSuite.scala
@@ -51,6 +51,16 @@ class TensorOpsFunctionalSuite extends AnyFunSpec with Matchers:
       val res = zipvmap(Axis[A])(t2, t2_2, t2_2, t2)((a, b, c, d) => l2(a, b) - l2(c, d))
       res should approxEqual(Tensor1(Axis[A]).fromArray(Array(0.0f, 0.0f)))
 
+    it("extension zipvmap with two different-shaped tensors"):
+      val ta = Tensor(Shape(Axis[A] -> 2, Axis[B] -> 3)).fill(1f)
+      val tc = Tensor(Shape(Axis[A] -> 2, Axis[C] -> 4)).fill(2f)
+      val res = ta.zipvmap(Axis[A])(tc) {
+        case (rowB, rowC) =>
+          rowB.sum + rowC.sum
+      }
+      // Each row of ta sums to 3.0, each row of tc sums to 8.0 => 11.0 per row
+      res.shouldEqual(Tensor1(Axis[A]).fromArray(Array(11.0f, 11.0f)))
+
   describe("vapply (Axis-wise application)"):
 
     def l2[L: Label](v1: Tensor1[L, Float], v2: Tensor1[L, Float]): Tensor0[Float] = (v1 - v2).pow(2.0f).sum.sqrt


### PR DESCRIPTION
The most common way to use `zipvmap` is with two arguments. Currently `vmap` and `vreduce` are available as an extension method, but not `zipvmap`. This PR propses to add them, making the method easier to explore in an ide. 