### PR TITLE
Add factory method to create tensors using a function of their index

### DIFF
--- a/core/src/main/scala/dimwit/package.scala
+++ b/core/src/main/scala/dimwit/package.scala
@@ -58,7 +58,7 @@ package object dimwit:
       val name: String = s"${labelA.name}+${labelB.name}"
 
   // Export tensor and related types
-  export dimwit.tensor.{Tensor, Tensor0, Tensor1, Tensor2, Tensor3}
+  export dimwit.tensor.{Tensor, Tensor0, Tensor1, Tensor2, Tensor3, TypedIndex}
   export dimwit.tensor.{Shape, Shape0, Shape1, Shape2, Shape3}
   export dimwit.tensor.DType
   export dimwit.tensor.DType.{BFloat16, Float16, Float32, Float64, Int8, Int16, Int32, Int64, UInt8, UInt16, UInt32, Bool}

--- a/core/src/main/scala/dimwit/tensor/Axis.scala
+++ b/core/src/main/scala/dimwit/tensor/Axis.scala
@@ -4,6 +4,7 @@ import dimwit.|*|
 import dimwit.tensor.DType.Int32
 
 import scala.compiletime.{constValue, erasedValue, summonInline}
+import ShapeTypeHelpers.AxisIndex
 
 /** Instances of this class represent an axis in a tensor with a specific label `L`.
   * Axis objects are used whenever an axis needs to be selected at the value level,
@@ -29,6 +30,12 @@ case class AxisExtent[L: Label](axis: Axis[L], size: Int):
     */
   def *[L2: Label](other: AxisExtent[L2]): AxisExtent[L |*| L2] =
     AxisExtent(Axis[L |*| L2], size * other.size)
+
+/** Provides typed access to the indices. I.e. the user can write `idx(Axis[A])` to get the index along axis A.
+  */
+class TypedIndex[T <: Tuple](private[dimwit] val coordInts: IndexedSeq[Int]):
+  def apply[L](axis: Axis[L])(using ev: AxisIndex[T, L]): Int =
+    coordInts(ev.index)
 
 /** Trait hierarchy to represent different ways to select an axis in a tensor, such as by index, range, or specific indices.
   */

--- a/core/src/main/scala/dimwit/tensor/Tensor.scala
+++ b/core/src/main/scala/dimwit/tensor/Tensor.scala
@@ -5,6 +5,7 @@ import scala.compiletime.{erasedValue, summonFrom}
 import dimwit.jax.Jax
 import dimwit.jax.JaxDType
 import dimwit.jax.Jax.PyDynamic
+import dimwit.tensor.TypedIndex
 import dimwit.tensor.{Label, Labels, VType}
 import me.shadaj.scalapy.py
 import me.shadaj.scalapy.py.SeqConverters
@@ -81,6 +82,28 @@ object Tensor:
     def fill(value: Boolean): Tensor[T, Bool] = Tensor(shape, VType[Bool]).fill(value)
     def fromArray(values: Array[Boolean]): Tensor[T, Bool] = Tensor(shape, VType[Bool]).fromArray(values)
 
+    @targetName("fromFunctionFloat")
+    def fromFunction(f: TypedIndex[T] => Float): Tensor[T, Float32] =
+      Tensor(shape, VType[Float32]).fromArray(Tensor.tabulate(shape.dimensions, f))
+    @targetName("fromFunctionDouble")
+    def fromFunction(f: TypedIndex[T] => Double): Tensor[T, Float64] =
+      Tensor(shape, VType[Float64]).fromArray(Tensor.tabulate(shape.dimensions, f))
+    @targetName("fromFunctionByte")
+    def fromFunction(f: TypedIndex[T] => Byte): Tensor[T, Int8] =
+      Tensor(shape, VType[Int8]).fromArray(Tensor.tabulate(shape.dimensions, f))
+    @targetName("fromFunctionShort")
+    def fromFunction(f: TypedIndex[T] => Short): Tensor[T, Int16] =
+      Tensor(shape, VType[Int16]).fromArray(Tensor.tabulate(shape.dimensions, f))
+    @targetName("fromFunctionInt")
+    def fromFunction(f: TypedIndex[T] => Int): Tensor[T, Int32] =
+      Tensor(shape, VType[Int32]).fromArray(Tensor.tabulate(shape.dimensions, f))
+    @targetName("fromFunctionLong")
+    def fromFunction(f: TypedIndex[T] => Long): Tensor[T, Int64] =
+      Tensor(shape, VType[Int64]).fromArray(Tensor.tabulate(shape.dimensions, f))
+    @targetName("fromFunctionBoolean")
+    def fromFunction(f: TypedIndex[T] => Boolean): Tensor[T, Bool] =
+      Tensor(shape, VType[Bool]).fromArray(Tensor.tabulate(shape.dimensions, f))
+
   case class TypedFactory[T <: Tuple: Labels, V](shape: Shape[T], vtype: VType[V]):
 
     // --- Boolean ---
@@ -121,6 +144,13 @@ object Tensor:
     def fill(value: Double): Tensor[T, V] = Tensor(Jax.jnp.full(other.shape.dimensions.toPythonProxy, value, dtype = other.dtype.jaxType))
     def fromArray(values: Array[Float])(using IsFloating[V]): Tensor[T, V] = ArrayWriter.fromArray[T, V](other.shape, values)
     def fromArray(values: Array[Double])(using IsFloating[V]): Tensor[T, V] = ArrayWriter.fromArray[T, V](other.shape, values)
+
+  /** Computes per-element values via eager Scala-side iteration. Used by [[DefaultsFactory.fromFunction]]. */
+  private[tensor] def tabulate[T <: Tuple, V: scala.reflect.ClassTag](dims: List[Int], f: TypedIndex[T] => V): Array[V] =
+    val strides = dims.scanRight(1)(_ * _).tail
+    Array.tabulate(dims.product) { flatIdx =>
+      f(TypedIndex[T](IndexedSeq.tabulate(dims.length)(d => (flatIdx / strides(d)) % dims(d))))
+    }
 
   private[dimwit] def apply[T <: Tuple: Labels, V](jaxValue: Jax.PyDynamic): Tensor[T, V] = new Tensor(jaxValue)
 

--- a/core/src/test/scala/dimwit/tensor/TensorCreationSuite.scala
+++ b/core/src/test/scala/dimwit/tensor/TensorCreationSuite.scala
@@ -66,3 +66,29 @@ class TensorCreationSuite extends DimwitTest:
       withJaxX64Support: // Enable float64 support in JAX
         val floatTensorFromDouble2 = Tensor(Shape2(Axis[A] -> 2, Axis[B] -> 2), VType[Float32]).fromArray(Array(1.0, 2.0, 3.0, 4.0))
         floatTensorFromDouble2.dtype shouldBe DType.Float32
+
+  describe("fromFunction"):
+
+    it("2D: identity matrix from indices"):
+      val result = Tensor(Shape(Axis[A] -> 3, Axis[B] -> 3)).fromFunction { idx =>
+        if idx(Axis[A]) == idx(Axis[B]) then 1.0f else 0.0f
+      }
+      val expected = Tensor2(Axis[A], Axis[B]).fromArray(
+        Array(Array(1.0f, 0.0f, 0.0f), Array(0.0f, 1.0f, 0.0f), Array(0.0f, 0.0f, 1.0f))
+      )
+      result shouldEqual expected
+
+    it("2D: element values are row + col index"):
+      val result = Tensor(Shape(Axis[A] -> 2, Axis[B] -> 3)).fromFunction { idx =>
+        (idx(Axis[A]) + idx(Axis[B])).toFloat
+      }
+      val expected = Tensor2(Axis[A], Axis[B]).fromArray(
+        Array(Array(0.0f, 1.0f, 2.0f), Array(1.0f, 2.0f, 3.0f))
+      )
+      result shouldEqual expected
+
+    it("1D: element values are their own index"):
+      val result = Tensor(Shape1(Axis[A] -> 4)).fromFunction { idx =>
+        idx(Axis[A]).toFloat
+      }
+      result shouldEqual Tensor1(Axis[A]).fromArray(Array(0.0f, 1.0f, 2.0f, 3.0f))


### PR DESCRIPTION
The current factory method for creating tensors are either relatively limited (fill, eye) or cumbersome to use for larger examples (fromArray). 
This PR proposed to add a flexibleinitializer that can take an arbitrary function for the tensor indices to initialize the elements. It is similar (but more restrictive) to Jax's  [fromFunction](https://docs.jax.dev/en/latest/_autosummary/jax.numpy.fromfunction.html).

#### Example
```
Tensor(Shape(Axis[A] -> 3, Axis[B] -> 3)).fromFunction(index =>
        if index(Axis[A]) == index(Axis[B])) then 1f
        else 0f
```