### PR TITLE
change dot on to accept pair of axis values instead of special axis type

### DIFF
--- a/core/src/main/scala/dimwit/package.scala
+++ b/core/src/main/scala/dimwit/package.scala
@@ -31,12 +31,6 @@ package object dimwit:
     System.gc()
     Jax.gc()
 
-  @targetName("On")
-  infix trait ~[A, B]
-  object `~`:
-    given [A, B](using labelA: Label[A], labelB: Label[B]): Label[A ~ B] with
-      val name: String = s"${labelA.name}_on_${labelB.name}"
-
   /** Combination of dimensions / labels
     *
     * Mentally think of this as the "product" of two dimensions.

--- a/core/src/main/scala/dimwit/tensor/TensorOps.scala
+++ b/core/src/main/scala/dimwit/tensor/TensorOps.scala
@@ -10,7 +10,7 @@ import dimwit.tensor.{Label, Labels}
 import dimwit.tensor.ShapeTypeHelpers.*
 import dimwit.tensor.TensorOps.Functional.ZipVmap.{ShapesOf, TensorsOf}
 import dimwit.tensor.TupleHelpers.*
-import dimwit.{~, `|*|`, `|+|`}
+import dimwit.{`|*|`, `|+|`}
 
 import me.shadaj.scalapy.py
 import me.shadaj.scalapy.py.SeqConverters
@@ -312,7 +312,7 @@ object TensorOps:
           ContractAxisA,
           ContractAxisB,
           OtherShape <: Tuple
-      ](axis: Axis[ContractAxisA ~ ContractAxisB])(other: Tensor[OtherShape, V])(using
+      ](axisPair: (Axis[ContractAxisA], Axis[ContractAxisB]))(other: Tensor[OtherShape, V])(using
           ev: AxisRemover[T, ContractAxisA],
           evOther: AxisRemover[OtherShape, ContractAxisB]
       )(using

--- a/core/src/test/scala/dimwit/tensor/TensorOpsContractionSuite.scala
+++ b/core/src/test/scala/dimwit/tensor/TensorOpsContractionSuite.scala
@@ -45,10 +45,10 @@ class TensorOpsContractionSuite extends DimwitTest:
       )
 
   describe("dot on different axis labels (A1 ~ A2)"):
-    it("Tensor2[A, B] and Tensor2[C, D] using Axis mapping (A ~ C)"):
+    it("Tensor2[A, B] and Tensor2[C, D] using Axis mapping (Axis[A] -> Axis[C])"):
       val mCD = m2.relabelAll((Axis[C], Axis[D]))
 
-      val res = m1.dot(Axis[A ~ C])(mCD)
+      val res = m1.dot(Axis[A] -> Axis[C])(mCD)
 
       res.shape.labels shouldBe List("B", "D")
       res should approxEqual(
@@ -57,10 +57,10 @@ class TensorOpsContractionSuite extends DimwitTest:
         )
       )
 
-    it("~ should respect position-aware mapping in types"):
+    it("Axis mapping should respect position-aware mapping in types"):
       val mCD = m2.relabelAll((Axis[C], Axis[D]))
-      "m1.dot(Axis[A ~ C])(mCD)" should compile
-      "m1.dot(Axis[C ~ A])(mCD)" shouldNot compile
+      "m1.dot(Axis[A] -> Axis[C])(mCD)" should compile
+      "m1.dot(Axis[C] -> Axis[A])(mCD)" shouldNot compile
 
   describe("outerProduct"):
     it("Tensor1[A] and Tensor1[B] to Tensor2[A, B]"):


### PR DESCRIPTION
Currently there is the special syntax 
```
dot(Axis[A~B])(t1, t2)
```
The type `A~B`  is hereby constructed at the type level. It seems more natural and consistent to just specify the axis on te value level
```
dot(Axis[A]->Axis[B](t1, t2)
``` 

In this way, the user does not need to learn a new concept but can just provide the normal axis values as for any other method in dimwit. 