### PR TITLE
fix broken link to gpt implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Alternatively, you can configure the Python environment manually using these env
 
 ## Status 
 
-**Early but functional.** DimWit successfully runs complex models including GPT-2 (see [example](examples/src/main/scala/complex/GPT2.scala)). The core concepts are stable, but the API is still evolving.
+**Early but functional.** DimWit successfully runs complex models including GPT-2 (see [example](https://github.com/dimwit-dev/deepwit/tree/main/examples/src/main/scala/example/gpt)). The core concepts are stable, but the API is still evolving.
 
 **Not production-ready** - expect breaking changes.
 

--- a/mdocs/README.md
+++ b/mdocs/README.md
@@ -123,7 +123,7 @@ Alternatively, you can configure the Python environment manually using these env
 
 ## Status 
 
-**Early but functional.** DimWit successfully runs complex models including GPT-2 (see [example](examples/src/main/scala/complex/GPT2.scala)). The core concepts are stable, but the API is still evolving.
+**Early but functional.** DimWit successfully runs complex models including GPT-2 (see [example](https://github.com/dimwit-dev/deepwit/tree/main/examples/src/main/scala/example/gpt)). The core concepts are stable, but the API is still evolving.
 
 **Not production-ready** - expect breaking changes.
 


### PR DESCRIPTION
When the GPT implementation was moved to deepwit, the example link in the README got broken. This PR fixes the link. 