### PR TITLE
remove scalaSource directive in example build definition

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -101,9 +101,6 @@ lazy val examples = (project in file("examples"))
     publish := {},
     publishLocal := {},
     publishArtifact := false,
-    // Examples source directory
-    Compile / scalaSource := baseDirectory.value,
-    Compile / resourceDirectory := baseDirectory.value / "src" / "main" / "resources",
     scalacOptions ++= commonScalacOptions,
     scalafmtFailOnErrors := false,
     javaOptions ++= {


### PR DESCRIPTION
The example sub-project uses the normal source directory (`src/main/scala`) and hence it is not necessary to specify it explicitly in `build.sbt`. Having it defined also seems to prevent the example project being correctly compiled when compiling the root project, even though the root project aggregates the example sub-project. 

This PR therefore proposes to remove the directive.