### PR TITLE
use tensordot to have proper generalized outer product

### DIFF
--- a/core/src/main/scala/dimwit/tensor/tensorops/ContractionOps.scala
+++ b/core/src/main/scala/dimwit/tensor/tensorops/ContractionOps.scala
@@ -26,11 +26,7 @@ object ContractionOps:
         primeConcat: PrimeConcat[T, OtherShape],
         labels: Labels[primeConcat.Out]
     ): Tensor[primeConcat.Out, V] = Tensor(
-      // Jax outer product flattens, reshape required
-      Jax.jnp.reshape(
-        Jax.jnp.outer(tensor.jaxValue, other.jaxValue),
-        (tensor.shape.dimensions ++ other.shape.dimensions).toPythonProxy
-      )
+      Jax.jnp.tensordot(tensor.jaxValue, other.jaxValue, axes = 0) // generalized outer product
     )
 
     /** Computes the dot product of this tensor with another tensor along the specified axis.

--- a/core/src/test/scala/dimwit/tensor/TensorOpsContractionSuite.scala
+++ b/core/src/test/scala/dimwit/tensor/TensorOpsContractionSuite.scala
@@ -73,3 +73,25 @@ class TensorOpsContractionSuite extends DimwitTest:
           Array(10.0f, 20.0f, 20.0f, 40.0f)
         )
       )
+
+    it("Tensor2[A, B] and Tensor2[C, D] to Tensor4[A, B, C, D]"):
+      val mAB = m1
+      val mCD = m2.relabelAll((Axis[C], Axis[D]))
+
+      val res = mAB.outerProduct(mCD)
+
+      res.shape.labels shouldBe List("A", "B", "C", "D")
+      res should approxEqual(
+        Tensor.like(res).fromArray(
+          Array(
+            10.0f, 20.0f,
+            30.0f, 40.0f,
+            20.0f, 40.0f,
+            60.0f, 80.0f,
+            30.0f, 60.0f,
+            90.0f, 120.0f,
+            40.0f, 80.0f,
+            120.0f, 160.0f
+          )
+        )
+      )


### PR DESCRIPTION
The outer product in dimwit is implemented using `jnp.outer`, which only works correctly for tensors of rank 1. 
This PR proposes to use `jnp.tensordot(.... axis=0)` instead, which is the generalized outer product, which works correctly for arbitrary tensors and corresponds to what the signature the method `outerProduct` promises. 