### PR TITLE
fix inconsistent example package clause and path

### DIFF
--- a/examples/src/main/scala/dimwit/basic/KMeans.scala
+++ b/examples/src/main/scala/dimwit/basic/KMeans.scala
@@ -1,4 +1,4 @@
-package examples.basic.kmeans
+package dimwit.examples.basic.kmeans
 
 import dimwit.Conversions.given
 import dimwit.*

--- a/examples/src/main/scala/dimwit/basic/LogisticRegression.scala
+++ b/examples/src/main/scala/dimwit/basic/LogisticRegression.scala
@@ -1,4 +1,4 @@
-package examples.basic
+package dimwit.examples.basic
 
 import dimwit.Conversions.given
 import dimwit.*

--- a/examples/src/main/scala/dimwit/basic/SIRSimulation.scala
+++ b/examples/src/main/scala/dimwit/basic/SIRSimulation.scala
@@ -1,4 +1,4 @@
-package src.main.scala.basic
+package dimwit.examples.basic
 
 import dimwit.*
 

--- a/examples/src/main/scala/dimwit/complex/VariationalAutoencoder.scala
+++ b/examples/src/main/scala/dimwit/complex/VariationalAutoencoder.scala
@@ -1,4 +1,4 @@
-package examples.complex.vae
+package dimwit.examples.complex.vae
 
 import dimwit.Conversions.given
 import dimwit.*
@@ -11,7 +11,7 @@ import dimwit.python.PyBridge.toPyTensor
 import dimwit.random.Random
 import dimwit.random.Random.Key
 import dimwit.stats.Normal
-import examples.dataset.MNISTLoader
+import dimwit.examples.dataset.MNISTLoader
 
 import MNISTLoader.Sample
 import MNISTLoader.TrainSample

--- a/examples/src/main/scala/dimwit/dataset/MNISTLoader.scala
+++ b/examples/src/main/scala/dimwit/dataset/MNISTLoader.scala
@@ -1,4 +1,4 @@
-package examples.dataset
+package dimwit.examples.dataset
 
 import dimwit.Conversions.given
 import dimwit.*


### PR DESCRIPTION
The path structure and package clause of the examples are inconsistent and lack dimwit as top level package. This commit makes the directory structure consistent and fixes the package clause.