### PR TITLE
NamedTuples failing for zipvmap

### DIFF
--- a/core/src/main/scala/dimwit/tensor/tensorops/FunctionalOps.scala
+++ b/core/src/main/scala/dimwit/tensor/tensorops/FunctionalOps.scala
@@ -11,25 +11,44 @@ import dimwit.tensor.ShapeTypeHelpers.AxisReplacer
 import dimwit.tensor.ShapeTypeHelpers.SharedAxisRemover
 import dimwit.tensor.Tensor
 import dimwit.tensor.Tensor0
-import dimwit.tensor.tensorops.FunctionalOps.ZipVmap.TensorsOf
+import dimwit.tensortree.TensorTree
 import me.shadaj.scalapy.py
 import me.shadaj.scalapy.py.SeqConverters
 import me.shadaj.scalapy.readwrite.Reader
 import me.shadaj.scalapy.readwrite.Writer
-import dimwit.tensortree.TensorTree
-import dimwit.tensor.ShapeTypeHelpers.UnwrapAxes
-import dimwit.tensor.ShapeTypeHelpers.AxesRemover
+
+import scala.NamedTuple.NamedTuple
 
 object FunctionalOps:
 
-  type PrependAxes[Axes <: Tuple, FOut] = Axes match
-    case EmptyTuple => FOut
-    case h *: t     => PrependAxis[h, PrependAxes[t, FOut]]
+  trait PrependAxis[L, FOut]:
+    type Out
 
-  type PrependAxis[L, FOut] = FOut match
-    case Tensor[shape, v] => Tensor[L *: shape, v]
-    case EmptyTuple       => EmptyTuple
-    case h *: t           => PrependAxis[L, h] *: PrependAxis[L, t]
+  object PrependAxis:
+    type Aux[L, FOut, Out0] = PrependAxis[L, FOut] { type Out = Out0 }
+
+    // Case 1: Tensor
+    given tensorCase[L, Shape <: Tuple, V]: PrependAxis[L, Tensor[Shape, V]] with
+      type Out = Tensor[L *: Shape, V]
+
+    // Case 2: EmptyTuple
+    given emptyTupleCase[L]: PrependAxis[L, EmptyTuple] with
+      type Out = EmptyTuple
+
+    // Case 3: Recursive Tuple (simplified without explicit tpOut variable)
+    given tupleCase[L, H, T <: Tuple, tpOut <: Tuple](using
+        hp: PrependAxis[L, H],
+        tp: PrependAxis.Aux[L, T, tpOut]
+    ): PrependAxis.Aux[L, H *: T, hp.Out *: tpOut] =
+      new PrependAxis[L, H *: T]:
+        type Out = hp.Out *: tpOut
+
+    // Case 4: NamedTuple
+    given namedTupleCase[L, Names <: Tuple, Values <: Tuple, vpOut <: Tuple](using
+        vp: PrependAxis.Aux[L, Values, vpOut]
+    ): PrependAxis.Aux[L, NamedTuple[Names, Values], NamedTuple[Names, vpOut]] =
+      new PrependAxis[L, NamedTuple[Names, Values]]:
+        type Out = NamedTuple[Names, vpOut]
 
   object ZipVmap:
 
@@ -72,9 +91,11 @@ object FunctionalOps:
     )(
         f: TensorsOf[ev.RemainingAxes, ValuesOf[Inputs]] => FOut
     )(using
+        prependAxis: PrependAxis[L, FOut]
+    )(using
         toPyTree: TensorTree[FOut],
-        fromPyTree: TensorTree[PrependAxis[L, FOut]]
-    ): PrependAxis[L, FOut] =
+        fromPyTree: TensorTree[prependAxis.Out]
+    ): prependAxis.Out =
       val fpy = (args: py.Dynamic) =>
         OnError.traceStack:
           val tensorList = args.as[Seq[py.Dynamic]].zip(ev.shapesLabels).map: (jaxArr, labels) =>
@@ -110,11 +131,13 @@ object FunctionalOps:
     )(using
         ev: SharedAxisRemover[(T, T2), L]
     )(
-        f: TensorsOf[ev.RemainingAxes, (V, V)] => FOut
+        f: ZipVmap.TensorsOf[ev.RemainingAxes, (V, V)] => FOut
+    )(using
+        prependAxis: PrependAxis[L, FOut]
     )(using
         toPyTree: TensorTree[FOut],
-        fromPyTree: TensorTree[PrependAxis[L, FOut]]
-    ): PrependAxis[L, FOut] =
+        fromPyTree: TensorTree[prependAxis.Out]
+    ): prependAxis.Out =
       ZipVmap.zipvmap(axis)(t, other)(f)
 
     /** Vectorized mapping over a specified axis of the tensor.
@@ -130,10 +153,12 @@ object FunctionalOps:
     )(
         f: Tensor[ev.RemainingAxes, V] => FOut
     )(using
+        prependAxis: PrependAxis[VmapAxis, FOut]
+    )(using
         toPyTree: TensorTree[FOut],
-        fromPyTree: TensorTree[PrependAxis[VmapAxis, FOut]],
+        fromPyTree: TensorTree[prependAxis.Out],
         labels: Labels[ev.RemainingAxes]
-    ): PrependAxis[VmapAxis, FOut] =
+    ): prependAxis.Out =
       val fpy = (jxpr: Jax.PyDynamic) =>
         OnError.traceStack:
           val innerTensor = Tensor[ev.RemainingAxes, V](jxpr)

--- a/core/src/test/scala/dimwit/tensor/TensorOpsFunctionalSuite.scala
+++ b/core/src/test/scala/dimwit/tensor/TensorOpsFunctionalSuite.scala
@@ -25,9 +25,17 @@ class TensorOpsFunctionalSuite extends DimwitTest:
     it("vmap return tuple"):
       val t = Tensor(Shape(Axis[A] -> 2, Axis[B] -> 3)).fill(0f)
       val (y1, y2) = t.vmap(Axis[A]): x =>
-        (x +! 5f, x -! 5f)
+        val tt = (x +! 5f, x -! 5f)
+        tt
       y1 shouldEqual (t +! 5f)
       y2 shouldEqual (t -! 5f)
+
+    it("vmap return named tuple"):
+      val t = Tensor(Shape(Axis[A] -> 2, Axis[B] -> 3)).fill(0f)
+      val res = t.vmap(Axis[A]): x =>
+        (first = x +! 5f, second = x -! 5f)
+      res.first shouldEqual (t +! 5f)
+      res.second shouldEqual (t -! 5f)
 
     it("vmap over Axis B (columns)"):
       val res = t2.vmap(Axis[B])(_.sum)


### PR DESCRIPTION
The current zipvmap and vmap do not yet support named tuples as the return type of f. I failed to achieve this by extending the PrependAxis match type. This PR provides a solution, but I am unsure whether removing the match type is necessary. This PR is a conversation starter about whether and how we can add named tuple support more cleanly with match types. And highlighting the lack of support.

Named tuples could be quite powerful, as the tuple names can be tracked across vmap and zipvmap operations. This is not possible for case classes with a fixed tensor structure. Here with explicit type alias to clarify what is (automatically) happening:

```scala
val t = Tensor(Shape(Axis[A] -> 2, Axis[B] -> 3)).fill(0f)
type FOut = (first: Tensor1[B, Float32], second: Tensor1[B, Float32]) // return named tuple of tensor
def f(x: Tensor1[B, Float32]): FOut =
  (first = x +! 5f, second = x -! 5f)
type TrackedOut = (first: Tensor2[A, B, Float32], second: Tensor2[A, B, Float32]) // automatically track names across tensor expansion
val res: TrackedOut = t.vmap(Axis[A]): x => // vmap automatically transforms FOut to TrackedOut (adds A axis to each field) keeps names
  f(x)
```