### PR TITLE
bugfix: take has wrong output type.

### DIFF
--- a/core/src/main/scala/dimwit/tensor/tensorops/StructuralOps.scala
+++ b/core/src/main/scala/dimwit/tensor/tensorops/StructuralOps.scala
@@ -653,9 +653,9 @@ object StructuralOps:
     )(
         indices: Tensor1[L2, Int32]
     )(using
-        ev: AxisRemover[T, L1],
-        labels: Labels[ev.RemainingAxes]
-    ): Tensor[Tuple.Concat[Tuple1[L2], ev.RemainingAxes], V] =
+        ev: AxisReplacer[T, L1, L2],
+        labels: Labels[ev.NewShape]
+    ): Tensor[ev.NewShape, V] =
       val result = Jax.jnp.take(tensor.jaxValue, indices.jaxValue, axis = ev.index)
       Tensor(result)
 


### PR DESCRIPTION
While working with DimWit I ran into the following issue:

If we "take" not the first dimension but later dimensions the returned type signatures is wrong. It adds the new dimension always at location 0 rather than the location where the axis is taken (like jnp.take). This PR fixes this issue.