### PR TITLE
Make DTypes sealed traits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -377,7 +377,7 @@ val wrong = t + 5.0f  // Use +! instead
 // error: 
 // Found:    (5.0f : Float)
 // Required: dimwit.tensor.Tensor[(MdocApp0.this.A, MdocApp0.this.B),
-//   (dimwit.tensor.DType.Float32 : dimwit.tensor.DType)]
+//   dimwit.tensor.DType.Float32]
 // error: 
 // Conflicting definitions:
 // val t:
@@ -1099,15 +1099,11 @@ val wrong = intTensor.exp  // exp requires IsFloating constraint
 // value exp is not a member of dimwit.tensor.Tensor1[MdocApp12.this.A, dimwit.tensor.DType.Int32].
 // An extension method was tried, but could not be fully constructed:
 // 
-//     dimwit.exp[Tuple1[MdocApp12.this.A],
-//       (dimwit.tensor.DType.Int32 : dimwit.tensor.DType)](this.intTensor)(
+//     dimwit.exp[Tuple1[MdocApp12.this.A], dimwit.tensor.DType.Int32](this.intTensor)(
 //       dimwit.tensor.Labels.concat[MdocApp12.this.A, EmptyTuple.type](
 //         this.A.derived$Label, dimwit.tensor.Labels.namesOfEmpty),
 //       /* missing */
-//         summon[
-//           dimwit.tensor.TensorOps.IsFloating[
-//             (dimwit.tensor.DType.Int32 : dimwit.tensor.DType)]
-//         ]
+//         summon[dimwit.tensor.TensorOps.IsFloating[dimwit.tensor.DType.Int32]]
 //     )
 // 
 //     failed with:
@@ -1123,15 +1119,12 @@ val wrong = boolTensor.mean
 // value mean is not a member of dimwit.tensor.Tensor1[MdocApp12.this.A, dimwit.tensor.DType.Bool].
 // An extension method was tried, but could not be fully constructed:
 // 
-//     dimwit.mean[Tuple1[MdocApp12.this.A],
-//       (dimwit.tensor.DType.Bool : dimwit.tensor.DType)](this.boolTensor)(
+//     dimwit.mean[Tuple1[MdocApp12.this.A], dimwit.tensor.DType.Bool](this.boolTensor)
+//       (
 //       dimwit.tensor.Labels.concat[MdocApp12.this.A, EmptyTuple.type](
 //         this.A.derived$Label, dimwit.tensor.Labels.namesOfEmpty),
 //       /* missing */
-//         summon[
-//           dimwit.tensor.TensorOps.IsFloating[
-//             (dimwit.tensor.DType.Bool : dimwit.tensor.DType)]
-//         ]
+//         summon[dimwit.tensor.TensorOps.IsFloating[dimwit.tensor.DType.Bool]]
 //     )
 // 
 //     failed with:
@@ -1151,8 +1144,7 @@ val wrong = t1 + t2  // Different labels AND different sizes
 // error: 
 // Found:    (MdocApp12.this.t2 :
 //   dimwit.tensor.Tensor1[MdocApp12.this.B, dimwit.tensor.DType.Float32])
-// Required: dimwit.tensor.Tensor[Tuple1[MdocApp12.this.A],
-//   (dimwit.tensor.DType.Float32 : dimwit.tensor.DType)]
+// Required: dimwit.tensor.Tensor[Tuple1[MdocApp12.this.A], dimwit.tensor.DType.Float32]
 ```
 
 ```scala
@@ -1190,7 +1182,7 @@ val wrong = t + 10.0f  // Should use +! for scalar broadcast
 // error: 
 // Found:    (10.0f : Float)
 // Required: dimwit.tensor.Tensor[(MdocApp12.this.A, MdocApp12.this.B),
-//   (dimwit.tensor.DType.Float32 : dimwit.tensor.DType)]
+//   dimwit.tensor.DType.Float32]
 ```
 
 ```scala
@@ -1205,7 +1197,7 @@ val wrong = t1 +! t2
 // 
 //     dimwit.tensor.tensorops.TensorOpsUtil.Broadcast.broadcastLeft[
 //       Tuple1[MdocApp12.this.A], Tuple1[MdocApp12.this.A],
-//       (dimwit.tensor.DType.Float32 : dimwit.tensor.DType)](
+//       dimwit.tensor.DType.Float32](
 //       dimwit.tensor.Labels.concat[MdocApp12.this.A, EmptyTuple.type](
 //         this.A.derived$Label, dimwit.tensor.Labels.namesOfEmpty),
 //       dimwit.tensor.Labels.concat[MdocApp12.this.A, EmptyTuple.type](

--- a/core/src/main/scala/dimwit/tensor/DType.scala
+++ b/core/src/main/scala/dimwit/tensor/DType.scala
@@ -11,51 +11,51 @@ import java.nio.ByteOrder
 
 object DType:
 
-  type UInt8 = UInt8.type
+  sealed trait UInt8
   given uint8IsFloating: IsInteger[UInt8] with
     def dtype: DType = DType.UInt8
 
-  type UInt16 = UInt16.type
+  sealed trait UInt16
   given uint16IsInteger: IsInteger[UInt16] with
     def dtype: DType = DType.UInt16
 
-  type UInt32 = UInt32.type
+  sealed trait UInt32
   given uint32IsInteger: IsInteger[UInt32] with
     def dtype: DType = DType.UInt32
 
-  type Int8 = Int8.type
+  sealed trait Int8
   given int8IsInteger: IsInteger[Int8] with
     def dtype: DType = DType.Int8
 
-  type Int16 = Int16.type
+  sealed trait Int16
   given int16IsInteger: IsInteger[Int16] with
     def dtype: DType = DType.Int16
 
-  type Int32 = Int32.type
+  sealed trait Int32
   given int32IsInteger: IsInteger[Int32] with
     def dtype: DType = DType.Int32
 
-  type Int64 = Int64.type
+  sealed trait Int64
   given int64IsInteger: IsInteger[Int64] with
     def dtype: DType = DType.Int64
 
-  type Float16 = Float16.type
+  sealed trait Float16
   given float16IsFloating: IsFloating[Float16] with
     def dtype: DType = DType.Float16
 
-  type BFloat16 = BFloat16.type
+  sealed trait BFloat16
   given bfloat16IsFloating: IsFloating[BFloat16] with
     def dtype: DType = DType.BFloat16
 
-  type Float32 = Float32.type
+  sealed trait Float32
   given float32IsFloating: IsFloating[Float32] with
     def dtype: DType = DType.Float32
 
-  type Float64 = Float64.type
+  sealed trait Float64
   given float64IsFloating: IsFloating[Float64] with
     def dtype: DType = DType.Float64
 
-  type Bool = Bool.type
+  sealed trait Bool
   given boolIsBoolean: IsBoolean[Bool] with
     def dtype: DType = DType.Bool
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -213,7 +213,7 @@ tensor1 + tensor3
 //     dimwit.tensor.DType.Float32]
 // )
 // Required: dimwit.tensor.Tensor[(MdocApp1.this.A, MdocApp1.this.B),
-//   (dimwit.tensor.DType.Float32 : dimwit.tensor.DType)]
+//   dimwit.tensor.DType.Float32]
 // tensor1 + tensor3 
 //           ^^^^^^^
 // error:
@@ -242,7 +242,7 @@ tensor1 + tensor3
 //     dimwit.tensor.DType.Float32]
 // )
 // Required: dimwit.tensor.Tensor[(MdocApp1.this.A, MdocApp1.this.B),
-//   (dimwit.tensor.DType.Float32 : dimwit.tensor.DType)]
+//   dimwit.tensor.DType.Float32]
 // tensor1 + tensor3
 //           ^^^^^^^
 ```


### PR DESCRIPTION
Making trait sealed makes VSCode show types better. Also it makes sense to make them not extendable.

After PR:
<img width="1184" height="116" alt="image" src="https://github.com/user-attachments/assets/d76cf88e-8bb9-4f52-95c5-59ef31017a67" />

Before:
<img width="1241" height="189" alt="image" src="https://github.com/user-attachments/assets/24ca7542-7662-4838-8c5f-0361dd20f87b" />
