### PR TITLE
Add where_! to broadcast where parameters.

### DIFF
--- a/core/src/main/scala/dimwit/tensor/tensorops/StructuralOps.scala
+++ b/core/src/main/scala/dimwit/tensor/tensorops/StructuralOps.scala
@@ -34,6 +34,7 @@ import dimwit.tensor.TensorEvidence.CheckValid
 import dimwit.tensor.TensorEvidence.ComputeMissing
 import dimwit.tensor.TensorEvidence.IsPermutation
 import dimwit.tensor.TensorEvidence.ValidationResult
+import dimwit.tensor.tensorops.TensorOpsUtil.Broadcast3
 import dimwit.|+|
 import me.shadaj.scalapy.py
 import me.shadaj.scalapy.py.SeqConverters
@@ -142,23 +143,34 @@ object StructuralOps:
   import Util.*
 
   object TensorWhere:
-    /** Returns a new tensor where elements are selected from `x` or `y`
-      * depending on the boolean condition.
-      *
-      * @param condition A tensor of boolean values that determines which elements to select.
-      * @param x A tensor from which to select elements when the condition is true.
-      * @param y A tensor from which to select elements when the condition is false.
-      *
-      * @return A new tensor with elements from `x` where the condition is true, and elements from `y` where the condition is false.
+
+    /** Returns a new tensor selecting elements from `ifTrue` where the condition is true
+      * and from `ifFalse` where it is false.
       */
     def where[T <: Tuple: Labels, V](
         condition: Tensor[T, Bool],
-        x: Tensor[T, V],
-        y: Tensor[T, V]
+        ifTrue: Tensor[T, V],
+        ifFalse: Tensor[T, V]
     ): Tensor[T, V] =
-      Tensor(Jax.jnp.where(condition.jaxValue, x.jaxValue, y.jaxValue))
+      Tensor(Jax.jnp.where(condition.jaxValue, ifTrue.jaxValue, ifFalse.jaxValue))
+
+    /** Like [[where]], but broadcasts condition, `ifTrue` and `ifFalse` to their common shape,
+      * which is the one of the three shapes containing all axes of the other two.
+      */
+    def where_![C <: Tuple, T <: Tuple, F <: Tuple, V](
+        condition: Tensor[C, Bool],
+        ifTrue: Tensor[T, V],
+        ifFalse: Tensor[F, V]
+    )(using
+        @implicitNotFound(
+          "Cannot broadcast condition ${C}, ifTrue ${T} and ifFalse ${F} to a common shape. One of them must contain all axes of the other two. If all have the same shape nothing has to be broadcast, use `where` instead of `where_!`."
+        ) bc: Broadcast3[C, T, F, V]
+    ): Tensor[bc.Out, V] =
+      val (c, t, f) = bc.broadcast(condition, ifTrue, ifFalse)
+      where(c, t, f)(using bc.labelsOut)
 
   export TensorWhere.where
+  export TensorWhere.where_!
 
   /** Returns a new tensor with the upper triangular part of the input tensor,
     * setting elements below the kth diagonal to zero.

--- a/core/src/main/scala/dimwit/tensor/tensorops/TensorOpsUtils.scala
+++ b/core/src/main/scala/dimwit/tensor/tensorops/TensorOpsUtils.scala
@@ -38,4 +38,60 @@ object TensorOpsUtil:
       def broadcast(t1: Tensor[T1, V], t2: Tensor[T2, V]) =
         (t1.broadcastTo[T2](t2.shape), t2)
 
+  /** Broadcasts three tensors to their common shape, which is the one of the three shapes containing all
+    * axes of the other two. As for [[Broadcast]] at least one of the tensors has to be broadcast.
+    */
+  @implicitNotFound(
+    "Cannot broadcast tensors of shapes ${T1}, ${T2} and ${T3}. One of them must contain all axes of the other two. If all same shape no broadcasting allowed!"
+  )
+  sealed trait Broadcast3[T1 <: Tuple, T2 <: Tuple, T3 <: Tuple, V]:
+    type Out <: Tuple
+    given labelsOut: Labels[Out]
+    def broadcast[V1](t1: Tensor[T1, V1], t2: Tensor[T2, V], t3: Tensor[T3, V]): (Tensor[Out, V1], Tensor[Out, V], Tensor[Out, V])
+
+  object Broadcast3 extends Broadcast3LowPriority:
+
+    /** `t2` and `t3` broadcast against each other, `t1` already has their common shape. */
+    given valuesBroadcast[O <: Tuple, T2 <: Tuple, T3 <: Tuple, V](using
+        bc: Broadcast[T2, T3, V] { type Out = O }
+    ): Broadcast3[O, T2, T3, V] with
+      type Out = O
+      val labelsOut = bc.labelsOut
+      def broadcast[V1](t1: Tensor[O, V1], t2: Tensor[T2, V], t3: Tensor[T3, V]) =
+        val (bt2, bt3) = bc.broadcast(t2, t3)
+        (t1, bt2, bt3)
+
+    /** `t2` and `t3` broadcast against each other, `t1` is broadcast to their common shape. */
+    given conditionAndValuesBroadcast[T1 <: Tuple: Labels, T2 <: Tuple, T3 <: Tuple, O <: Tuple, V](using
+        bc: Broadcast[T2, T3, V] { type Out = O },
+        ev: StrictSubset[T1, O]
+    ): Broadcast3[T1, T2, T3, V] with
+      type Out = O
+      val labelsOut = bc.labelsOut
+      def broadcast[V1](t1: Tensor[T1, V1], t2: Tensor[T2, V], t3: Tensor[T3, V]) =
+        given Labels[O] = bc.labelsOut
+        val (bt2, bt3) = bc.broadcast(t2, t3)
+        (t1.broadcastTo[O](bt2.shape), bt2, bt3)
+
+    /** `t2` and `t3` have the same shape, only `t1` is broadcast to it. */
+    given conditionBroadcast[T1 <: Tuple: Labels, T <: Tuple: Labels, V](using
+        ev: StrictSubset[T1, T]
+    ): Broadcast3[T1, T, T, V] with
+      type Out = T
+      val labelsOut = summon[Labels[T]]
+      def broadcast[V1](t1: Tensor[T1, V1], t2: Tensor[T, V], t3: Tensor[T, V]) =
+        (t1.broadcastTo[T](t2.shape), t2, t3)
+
+  trait Broadcast3LowPriority:
+
+    /** `t2` and `t3` are both broadcast to the shape of `t1`. */
+    given valuesBroadcastToFirst[T1 <: Tuple: Labels, T2 <: Tuple: Labels, T3 <: Tuple: Labels, V](using
+        ev2: StrictSubset[T2, T1],
+        ev3: StrictSubset[T3, T1]
+    ): Broadcast3[T1, T2, T3, V] with
+      type Out = T1
+      val labelsOut = summon[Labels[T1]]
+      def broadcast[V1](t1: Tensor[T1, V1], t2: Tensor[T2, V], t3: Tensor[T3, V]) =
+        (t1, t2.broadcastTo[T1](t1.shape), t3.broadcastTo[T1](t1.shape))
+
 end TensorOpsUtil

--- a/core/src/test/scala/dimwit/tensor/TensorOpsStructureSuite.scala
+++ b/core/src/test/scala/dimwit/tensor/TensorOpsStructureSuite.scala
@@ -335,6 +335,71 @@ class TensorOpsStructureSuite extends DimwitTest:
         )
       )
 
+  describe("where_!"):
+
+    val tAB = Tensor2(Axis[A], Axis[B]).fromArray(
+      Array(
+        Array(1.0f, 2.0f),
+        Array(3.0f, 4.0f)
+      )
+    )
+    val maskAB = Tensor2(Axis[A], Axis[B]).fromArray(
+      Array(
+        Array(true, true),
+        Array(false, false)
+      )
+    )
+
+    it("broadcasts a Tensor0"):
+      where_!(maskAB, tAB, Tensor0(0.0f)) should approxEqual(
+        Tensor.like(tAB).fromArray(Array(1.0f, 2.0f, 0.0f, 0.0f))
+      )
+      where_!(maskAB, Tensor0(0.0f), tAB) should approxEqual(
+        Tensor.like(tAB).fromArray(Array(0.0f, 0.0f, 3.0f, 4.0f))
+      )
+
+    it("broadcasts a tensor with a subset of the labels"):
+      val tB = Tensor1(Axis[B]).fromArray(Array(10.0f, 20.0f))
+      where_!(maskAB, tAB, tB) should approxEqual(
+        Tensor.like(tAB).fromArray(Array(1.0f, 2.0f, 10.0f, 20.0f))
+      )
+      where_!(maskAB, tB, tAB) should approxEqual(
+        Tensor.like(tAB).fromArray(Array(10.0f, 20.0f, 3.0f, 4.0f))
+      )
+
+    it("broadcasts the condition"):
+      val maskA = Tensor1(Axis[A]).fromArray(Array(true, false))
+      val tAB2 = Tensor.like(tAB).fromArray(Array(10.0f, 20.0f, 30.0f, 40.0f))
+      where_!(maskA, tAB, tAB2) should approxEqual(
+        Tensor.like(tAB).fromArray(Array(1.0f, 2.0f, 30.0f, 40.0f))
+      )
+
+    it("broadcasts the condition and an alternative"):
+      val maskA = Tensor1(Axis[A]).fromArray(Array(true, false))
+      where_!(maskA, tAB, Tensor0(0.0f)) should approxEqual(
+        Tensor.like(tAB).fromArray(Array(1.0f, 2.0f, 0.0f, 0.0f))
+      )
+      where_!(maskA, Tensor0(0.0f), tAB) should approxEqual(
+        Tensor.like(tAB).fromArray(Array(0.0f, 0.0f, 3.0f, 4.0f))
+      )
+
+    it("broadcasts both alternatives to the shape of the condition"):
+      val tA = Tensor1(Axis[A]).fromArray(Array(1.0f, 2.0f))
+      val tB = Tensor1(Axis[B]).fromArray(Array(10.0f, 20.0f))
+      where_!(maskAB, tA, tB) should approxEqual(
+        Tensor.like(tAB).fromArray(Array(1.0f, 1.0f, 10.0f, 20.0f))
+      )
+
+    it("must require broadcasting"):
+      val tAB2 = Tensor.like(tAB).fromArray(Array(10.0f, 20.0f, 30.0f, 40.0f))
+      val errors = typeCheckErrors("where_!(maskAB, tAB, tAB2)")
+      errors should have size 1
+      errors.head.message should include("use `where` instead of `where_!`")
+
+    it("rejects shapes that are not nested"):
+      val tC = Tensor1(Axis[C]).fromArray(Array(10.0f))
+      "where_!(maskAB, tAB, tC)" shouldNot compile
+
   describe("Concatenation"):
 
     it("Prime axes are rearrangable"):


### PR DESCRIPTION
This PR adds the where_! operations teased in #154

```scala
val tAB = Tensor2(Axis[A], Axis[B]).fromArray(
  Array(
    Array(1.0f, 2.0f),
    Array(3.0f, 4.0f)
  )
)
val maskA = Tensor1(Axis[A]).fromArray(Array(true, false))
where_!(maskA, tAB, Tensor0(0.0f))
```

It supports broadcasting conditions and both alternatives. One of them or two of them. It requires broadcasting like +! requires broadcasting so this would fail:

```scala
where_!(maskA, maskA, maskA) // Compile error as should be "where" not "where_!"
```